### PR TITLE
Don't convert modId to integer

### DIFF
--- a/lib/fmrest/spyke/json_parser.rb
+++ b/lib/fmrest/spyke/json_parser.rb
@@ -40,7 +40,7 @@ module FmRest
         response = json[:response]
 
         data = {}
-        data[:mod_id] = response[:modId].to_i if response[:modId]
+        data[:mod_id] = response[:modId] if response[:modId]
         data[:id]     = response[:recordId].to_i if response[:recordId]
 
         build_base_hash(json, true).merge!(data: data)
@@ -116,7 +116,7 @@ module FmRest
       # @param json_data [Hash]
       # @return [Hash] the record data in Spyke format
       def prepare_record_data(json_data)
-        out = { id: json_data[:recordId].to_i, mod_id: json_data[:modId].to_i }
+        out = { id: json_data[:recordId].to_i, mod_id: json_data[:modId] }
         out.merge!(json_data[:fieldData])
         out.merge!(prepare_portal_data(json_data[:portalData])) if json_data[:portalData]
         out
@@ -142,7 +142,7 @@ module FmRest
           out[portal_name] =
             portal_records.map do |portal_fields|
               attributes = { id: portal_fields[:recordId].to_i }
-              attributes[:mod_id] = portal_fields[:modId].to_i if portal_fields[:modId]
+              attributes[:mod_id] = portal_fields[:modId] if portal_fields[:modId]
 
               prefix = portal_options[:attribute_prefix] || portal_name
               prefix_matcher = /\A#{prefix}::/

--- a/spec/spyke/json_parser_spec.rb
+++ b/spec/spyke/json_parser_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe FmRest::Spyke::JsonParser do
           portalData: {
             portal1: [{
               "PortalOne::bar": "Bar",
-              recordId: 1,
-              modId: 1
+              recordId: "1",
+              modId: "1"
             }]
           },
 
-          modId: 1,
-          recordId: 1
+          modId: "1",
+          recordId: "1"
         }],
       },
       messages: [{ code: "0", message: "OK" }]
@@ -69,9 +69,9 @@ RSpec.describe FmRest::Spyke::JsonParser do
         },
         data: {
           id: 1,
-          mod_id: 1,
+          mod_id: "1",
           foo: "Foo",
-          portal1: [{ bar: "Bar", id: 1, mod_id: 1 }]
+          portal1: [{ bar: "Bar", id: 1, mod_id: "1" }]
         }
       )
     end
@@ -87,9 +87,9 @@ RSpec.describe FmRest::Spyke::JsonParser do
         },
         data: [{
           id: 1,
-          mod_id: 1,
+          mod_id: "1",
           foo: "Foo",
-          portal1: [{ bar: "Bar", id: 1, mod_id: 1 }]
+          portal1: [{ bar: "Bar", id: 1, mod_id: "1" }]
         }]
       )
     end
@@ -105,9 +105,9 @@ RSpec.describe FmRest::Spyke::JsonParser do
         },
         data: [{
           id: 1,
-          mod_id: 1,
+          mod_id: "1",
           foo: "Foo",
-          portal1: [{ bar: "Bar", id: 1, mod_id: 1 }]
+          portal1: [{ bar: "Bar", id: 1, mod_id: "1" }]
         }]
       )
     end
@@ -120,7 +120,7 @@ RSpec.describe FmRest::Spyke::JsonParser do
       context "when sucessful" do
         let :response_json do
           {
-            response: { modId: 2 },
+            response: { modId: "2" },
             messages: [{code: "0", message: "OK"}]
           }
         end
@@ -130,7 +130,7 @@ RSpec.describe FmRest::Spyke::JsonParser do
             metadata: {
               messages: [{code: "0", message: "OK"}]
             },
-            data: { mod_id: 2 },
+            data: { mod_id: "2" },
             errors: {}
           )
         end

--- a/spec/spyke/model/associations_spec.rb
+++ b/spec/spyke/model/associations_spec.rb
@@ -36,21 +36,21 @@ RSpec.describe FmRest::Spyke::Model::Associations do
                     {
                       "Pirate::name": "Hendrick van der Decken",
                       "Pirate::rank": "Captain",
-                      recordId: 1,
-                      modId: 0
+                      recordId: "1",
+                      modId: "0"
                     },
 
                     {
                       "Pirate::name": "Marthijn van het Vriesendijks",
                       "Pirate::rank": "First Officer",
-                      recordId: 2,
-                      modId: 0
+                      recordId: "2",
+                      modId: "0"
                     }
                   ]
                 },
 
-                recordId: 1,
-                modId: 0
+                recordId: "1",
+                modId: "0"
               }
             ]
           )
@@ -63,7 +63,7 @@ RSpec.describe FmRest::Spyke::Model::Associations do
           expect(ship.crew.first).to be_a(Pirate)
           expect(ship.crew.first.name).to eq("Hendrick van der Decken")
           expect(ship.crew.first.id).to eq(1)
-          expect(ship.crew.first.mod_id).to eq(0)
+          expect(ship.crew.first.mod_id).to eq("0")
           expect(ship.crew.first).to_not be_changed
           expect(ship.crew.last.id).to eq(2)
         end

--- a/spec/spyke/model/attributes_spec.rb
+++ b/spec/spyke/model/attributes_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe FmRest::Spyke::Model::Attributes do
           data: [
             {
               fieldData: { name: "Obra Djinn" },
-              recordId: 1,
-              modId: 0
+              recordId: "1",
+              modId: "0"
             }
           ]
         )

--- a/spec/spyke/model/orm_spec.rb
+++ b/spec/spyke/model/orm_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe FmRest::Spyke::Model::Orm do
       before do
         allow(ship).to receive(:valid?).and_return(false)
 
-        stub_request(:post, fm_url(layout: "Ships") + "/records").to_return_fm(recordId: 1, modId: 1)
+        stub_request(:post, fm_url(layout: "Ships") + "/records").to_return_fm(recordId: "1", modId: "1")
       end
 
       it "raises ActiveModel::ValidationError when called with no options" do
@@ -167,7 +167,7 @@ RSpec.describe FmRest::Spyke::Model::Orm do
 
       context "when the server responds successfully" do
         before do
-          stub_request(:post, fm_url(layout: "Ships") + "/records").to_return_fm(recordId: 1, modId: 1)
+          stub_request(:post, fm_url(layout: "Ships") + "/records").to_return_fm(recordId: "1", modId: "1")
         end
 
         it "returns true" do
@@ -217,8 +217,8 @@ RSpec.describe FmRest::Spyke::Model::Orm do
     context "with a successful save" do
       before do
         stub_request(:post, fm_url(layout: "Ships") + "/records").to_return_fm(
-          recordId: 1,
-          modId: 0
+          recordId: "1",
+          modId: "0"
         )
       end
 
@@ -248,7 +248,7 @@ RSpec.describe FmRest::Spyke::Model::Orm do
 
     before do
       stub_request(:get, fm_url(layout: "Ships") + "/records/1").to_return_fm(
-        data: [{ recordId: 1, modId: 2, fieldData: { name: "Obra Dinn Reloaded" } }]
+        data: [{ recordId: "1", modId: "2", fieldData: { name: "Obra Dinn Reloaded" } }]
       )
     end
 
@@ -257,7 +257,7 @@ RSpec.describe FmRest::Spyke::Model::Orm do
     end
 
     it "sets the mod_id" do
-      expect { ship.reload }.to change { ship.mod_id }.from(nil).to(2)
+      expect { ship.reload }.to change { ship.mod_id }.from(nil).to("2")
     end
   end
 


### PR DESCRIPTION
- store `modId` in whatever format we received from the API

The API gives us `modId` as a string and expects us to send it back as a string. We were converting it to an integer, which didn't seem to cause any trouble for the FM 17 API, but breaks things with the FM 18 API.