### PR TITLE
Raise error, when trying to map an attribute to id

### DIFF
--- a/lib/fmrest/spyke/model/attributes.rb
+++ b/lib/fmrest/spyke/model/attributes.rb
@@ -83,6 +83,9 @@ module FmRest
             # directly with #[]= so that we don't change the mapped_attributes
             # hash on the parent class. The resulting hash is frozen for the
             # same reason.
+
+            raise ArgumentError, "id is reserved for the record_id" if from == :id
+
             self.mapped_attributes = mapped_attributes.merge(from => to).freeze
 
             _fmrest_attribute_methods_container.module_eval do

--- a/spec/spyke/model/attributes_spec.rb
+++ b/spec/spyke/model/attributes_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe FmRest::Spyke::Model::Attributes do
       expect(instance).to respond_to(:foo_will_change!)
       expect(instance.foo_changed?).to be(true)
     end
+
+    it "raises an error, if attempting to set an attribute named id" do
+      expect do
+        fmrest_spyke_class do
+          attributes id: "Foo", bar: "Bar"
+        end
+      end.to raise_error("id is reserved for the record_id")
+    end
   end
 
   describe ".mapped_attributes" do


### PR DESCRIPTION
I mapped an internal id to `id` and spent a long time figuring out, why I could not save or update my model, before realizing that `id` is reserved for the record id. If `id` is reserved, we should raise an error, when trying to map an attribute to it.