### PR TITLE
Use ERB::Util.url_encode instead of deprecated URI.escape

### DIFF
--- a/lib/fmrest/v1/paths.rb
+++ b/lib/fmrest/v1/paths.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-
 module FmRest
   module V1
     module Paths
@@ -12,20 +10,20 @@ module FmRest
       end
 
       def record_path(layout, id = nil)
-        url = "layouts/#{URI.escape(layout.to_s)}/records"
+        url = "layouts/#{ERB::Util.url_encode(layout.to_s)}/records"
         url += "/#{id}" if id
         url
       end
 
       def container_field_path(layout, id, field_name, field_repetition = 1)
         url = record_path(layout, id)
-        url += "/containers/#{URI.escape(field_name.to_s)}"
+        url += "/containers/#{ERB::Util.url_encode(field_name.to_s)}"
         url += "/#{field_repetition}" if field_repetition
         url
       end
 
       def find_path(layout)
-        "layouts/#{URI.escape(layout.to_s)}/_find"
+        "layouts/#{ERB::Util.url_encode(layout.to_s)}/_find"
       end
 
       def globals_path

--- a/spec/fmrest/v1/paths_spec.rb
+++ b/spec/fmrest/v1/paths_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe FmRest::V1::Paths do
     it "returns layouts/:layout/records/:id when called with an id" do
       expect(extendee.record_path("Some Layout", 1337)).to eq("layouts/Some%20Layout/records/1337")
     end
+
+    it "encodes the url correctly when a layout contains brackets and spaces" do
+      expect(extendee.record_path("Some Layout [horribleUrL]")).to eq("layouts/Some%20Layout%20%5BhorribleUrL%5D/records")
+    end
   end
 
   describe "#container_field_path" do


### PR DESCRIPTION
In a current project, I came across a layout name that got parsed incorrectly when making the url. Using ERB::Util.url_encode instead of URI.escape fixes this.