### PR TITLE
Execute scripts

### DIFF
--- a/lib/fmrest/spyke/json_parser.rb
+++ b/lib/fmrest/spyke/json_parser.rb
@@ -11,6 +11,7 @@ module FmRest
       MULTIPLE_RECORDS_RE = %r(/records\z).freeze
       CONTAINER_RE = %r(/records/\d+/containers/[^/]+/\d+\z).freeze
       FIND_RECORDS_RE = %r(/_find\b).freeze
+      SCRIPT_REQUEST_RE = %r(/script\b).freeze
 
       VALIDATION_ERROR_RANGE = 500..599
 
@@ -32,6 +33,8 @@ module FmRest
           env.body = prepare_collection(json)
         when create_request?(env), update_request?(env), delete_request?(env), container_upload_request?(env)
           env.body = prepare_save_response(json)
+        when execute_script_request?(env)
+          env.body = build_base_hash(json)
         end
       end
 
@@ -194,6 +197,10 @@ module FmRest
       # (see #single_record_request?)
       def delete_request?(env)
         env.method == :delete && env.url.path.match(SINGLE_RECORD_RE)
+      end
+
+      def execute_script_request?(env)
+        env.method == :get && env.url.path.match(SCRIPT_REQUEST_RE)
       end
 
       # @param source [String] a JSON string

--- a/lib/fmrest/spyke/model/orm.rb
+++ b/lib/fmrest/spyke/model/orm.rb
@@ -66,7 +66,9 @@ module FmRest
             new(attributes).tap(&:save!)
           end
 
-          def execute_script(script_name, params: {})
+          def execute_script(script_name, param: nil)
+            params = {}
+            params = {"script.param" => param} unless param.nil?
             request(:get, FmRest::V1::script_path(layout, script_name), params)
           end
 

--- a/lib/fmrest/spyke/model/orm.rb
+++ b/lib/fmrest/spyke/model/orm.rb
@@ -66,6 +66,10 @@ module FmRest
             new(attributes).tap(&:save!)
           end
 
+          def execute_script(script_name, params: {})
+            request(:get, FmRest::V1::script_path(layout, script_name), params)
+          end
+
           private
 
           def extend_scope_with_fm_params(scope, prefixed: false)

--- a/lib/fmrest/v1/paths.rb
+++ b/lib/fmrest/v1/paths.rb
@@ -26,6 +26,10 @@ module FmRest
         "layouts/#{url_encode(layout)}/_find"
       end
 
+      def script_path(layout, script)
+        "layouts/#{url_encode(layout)}/script/#{url_encode(script)}"
+      end
+
       def globals_path
         "globals"
       end

--- a/spec/fmrest/v1/paths_spec.rb
+++ b/spec/fmrest/v1/paths_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe FmRest::V1::Paths do
     end
   end
 
+  describe "#script_path" do
+    it "returns layouts/:layout/scripts/:script" do
+      expect(extendee.script_path("Some Layout", "Some script")).to eq("layouts/Some%20Layout/script/Some%20script")
+    end
+  end
+
   describe "#globals_path" do
     it "returns globals" do
       expect(extendee.globals_path).to eq("globals")

--- a/spec/spyke/model/orm_spec.rb
+++ b/spec/spyke/model/orm_spec.rb
@@ -379,5 +379,25 @@ RSpec.describe FmRest::Spyke::Model::Orm do
       Ship.create!({})
     end
   end
+
+  describe "#execute_script" do
+    before { stub_session_login }
+
+    it "runs the script indicated" do
+      request = stub_request(:get, fm_url(layout: "Ships") + "/script/clear_data").to_return_fm
+
+      Ship.execute_script("clear_data")
+
+      expect(request).to have_been_requested
+    end
+
+    it "raises error when script is missing" do
+      request = stub_request(:get, fm_url(layout: "Ships") + "/script/bleh").to_return_fm(
+        104
+      )
+
+      expect { Ship.execute_script("bleh") }.to raise_error(FmRest::APIError::ResourceMissingError)
+    end
+  end
 end
 

--- a/spec/spyke/model/orm_spec.rb
+++ b/spec/spyke/model/orm_spec.rb
@@ -398,6 +398,14 @@ RSpec.describe FmRest::Spyke::Model::Orm do
 
       expect { Ship.execute_script("bleh") }.to raise_error(FmRest::APIError::ResourceMissingError)
     end
+
+    it "sends along any passed parameters" do
+      request = stub_request(:get, fm_url(layout: "Ships") + "/script/clear_data?script.param=someString").to_return_fm
+
+      Ship.execute_script("clear_data", param: "someString")
+
+      expect(request).to have_been_requested
+    end
   end
 end
 


### PR DESCRIPTION
Filemaker 18 adds support for running scripts on their own - without them being a part of another (sometimes unnecessary) call to the db. For the docs, see https://fmhelp.filemaker.com/docs/18/en/dataapi/index.html#running-scripts_run-a-script
This PR adds an `execute_script `method to `fmrest/spyke/model/orm.rb` that provides this functionality.