### PR TITLE
Multi-sessions

### DIFF
--- a/lib/fmrest.rb
+++ b/lib/fmrest.rb
@@ -4,10 +4,12 @@ require "faraday"
 require "faraday_middleware"
 
 require "fmrest/version"
-require "fmrest/v1"
 require "fmrest/connection_settings"
 
 module FmRest
+  autoload :V1,         "fmrest/v1"
+  autoload :TokenStore, "fmrest/token_store"
+
   class << self
     attr_accessor :token_store
 

--- a/lib/fmrest.rb
+++ b/lib/fmrest.rb
@@ -5,15 +5,18 @@ require "faraday_middleware"
 
 require "fmrest/version"
 require "fmrest/v1"
+require "fmrest/connection_settings"
 
 module FmRest
   class << self
     attr_accessor :token_store
 
-    attr_writer :default_connection_settings
+    def default_connection_settings=(settings)
+      @default_connection_settings = ConnectionSettings.wrap(settings, skip_validation: true)
+    end
 
     def default_connection_settings
-      @default_connection_settings || {}
+      @default_connection_settings || ConnectionSettings.new({}, skip_validation: true)
     end
 
     def config=(connection_hash)

--- a/lib/fmrest/connection_settings.rb
+++ b/lib/fmrest/connection_settings.rb
@@ -84,6 +84,11 @@ module FmRest
       end
     end
 
+    def merge(other, **keyword_args)
+      other = self.class.wrap(other, skip_validation: true)
+      self.class.new(to_h.merge(other.to_h), **keyword_args)
+    end
+
     def validate
       missing = REQUIRED.select { |r| get(r).nil? }.map { |m| "`#{m}'" }
       raise ValidationError, "Missing required: #{missing.join(', ')}" unless missing.empty?

--- a/lib/fmrest/connection_settings.rb
+++ b/lib/fmrest/connection_settings.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module FmRest
+  # Wrapper class for connection settings hash, with a number of purposes:
+  #
+  # * Provide indifferent access (base hash can have either string or symbol
+  #   keys)
+  # * Method access
+  # * Default values
+  # * Basic validation
+  # * Normalization (e.g. aliased settings)
+  # * Useful error messages
+  class ConnectionSettings
+    class ValidationError < ArgumentError; end
+
+    PROPERTIES = %i(
+      host
+      database
+      username
+      password
+      token_store
+      ssl
+      proxy
+      log
+      coerce_dates
+      date_format
+      timestamp_format
+      time_format
+      timezone
+    ).freeze
+
+    REQUIRED = %i(
+      host
+      database
+      username
+      password
+    ).freeze
+
+    DEFAULT_DATE_FORMAT = "MM/dd/yyyy"
+    DEFAULT_TIME_FORMAT = "HH:mm:ss"
+    DEFAULT_TIMESTAMP_FORMAT = "#{DEFAULT_DATE_FORMAT} #{DEFAULT_TIME_FORMAT}"
+
+    DEFAULTS = {
+      log:              false,
+      date_format:      DEFAULT_DATE_FORMAT,
+      time_format:      DEFAULT_TIME_FORMAT,
+      timestamp_format: DEFAULT_TIMESTAMP_FORMAT,
+      coerce_dates:     false
+    }.freeze
+
+    def self.wrap(settings, skip_validation: false)
+      if settings.kind_of?(self)
+        settings.validate unless skip_validation
+        return settings
+      end
+      new(settings, skip_validation: skip_validation)
+    end
+
+    def initialize(settings, skip_validation: false)
+      @settings = settings.to_h.dup
+      normalize
+      validate unless skip_validation
+    end
+
+    PROPERTIES.each do |p|
+      define_method(p) do
+        get(p)
+      end
+
+      define_method("#{p}?") do
+        !!get(p)
+      end
+    end
+
+    def [](key)
+      raise ArgumentError, "Unknown property `#{key}'" unless PROPERTIES.include?(key.to_sym)
+      get(key)
+    end
+
+    def to_h
+      PROPERTIES.each_with_object({}) do |p, h|
+        v = get(p)
+        h[p] = v unless v == DEFAULTS[p]
+      end
+    end
+
+    def validate
+      missing = REQUIRED.select { |r| get(r).nil? }.map { |m| "`#{m}'" }
+      raise ValidationError, "Missing required: #{missing.join(', ')}" unless missing.empty?
+    end
+
+    private
+
+    def get(key)
+      @settings[key.to_sym] || @settings[key.to_s] || DEFAULTS[key.to_sym]
+    end
+
+    def normalize
+      if !get(:username) && account_name = get(:account_name)
+        @settings[:username] = account_name
+      end
+    end
+  end
+end

--- a/lib/fmrest/errors.rb
+++ b/lib/fmrest/errors.rb
@@ -21,6 +21,8 @@ module FmRest
   class APIError::NoMatchingRecordsError < APIError::ParameterError; end
   class APIError::ValidationError < APIError; end      # error codes 500..599
   class APIError::SystemError < APIError; end          # error codes 800..899
+  class APIError::InvalidToken < APIError; end         # error code 952
+  class APIError::MaximumDataAPICallsExceeded < APIError; end # error code 953
   class APIError::ScriptError < APIError; end          # error codes 1200..1299
   class APIError::ODBCError < APIError; end            # error codes 1400..1499
 

--- a/lib/fmrest/spyke/model/auth.rb
+++ b/lib/fmrest/spyke/model/auth.rb
@@ -28,6 +28,14 @@ module FmRest
           rescue FmRest::V1::TokenSession::NoSessionTokenSet
             false
           end
+
+          def request_auth_token
+            FmRest::V1.request_auth_token(FmRest::V1.auth_connection(fmrest_config))
+          end
+
+          def request_auth_token!
+            FmRest::V1.request_auth_token!(FmRest::V1.auth_connection(fmrest_config))
+          end
         end
       end
     end

--- a/lib/fmrest/spyke/model/connection.rb
+++ b/lib/fmrest/spyke/model/connection.rb
@@ -10,7 +10,7 @@ module FmRest
           class_attribute :fmrest_config, instance_writer: false, instance_predicate: false
 
           # Overrides the fmrest_config reader created by class_attribute so we
-          # can default set the default at call time.
+          # can set the default at call time.
           #
           # This method gets overwriten in subclasses if self.fmrest_config= is
           # called.
@@ -49,7 +49,7 @@ module FmRest
           def fmrest_connection
             @fmrest_connection ||=
               begin
-                config = fmrest_config
+                config = ConnectionSettings.wrap(fmrest_config)
 
                 FmRest::V1.build_connection(config) do |conn|
                   faraday_block.call(conn) if faraday_block

--- a/lib/fmrest/spyke/model/connection.rb
+++ b/lib/fmrest/spyke/model/connection.rb
@@ -7,25 +7,66 @@ module FmRest
         extend ActiveSupport::Concern
 
         included do
-          class_attribute :fmrest_config, instance_writer: false, instance_predicate: false
-
-          # Overrides the fmrest_config reader created by class_attribute so we
-          # can set the default at call time.
-          #
-          # This method gets overwriten in subclasses if self.fmrest_config= is
-          # called.
-          define_singleton_method(:fmrest_config) do
-            FmRest.default_connection_settings
-          end
-
           class_attribute :faraday_block, instance_accessor: false, instance_predicate: false
           class << self; private :faraday_block, :faraday_block=; end
 
-          # FM Data API expects PATCH for updates (Spyke's default was PUT)
+          # FM Data API expects PATCH for updates (Spyke's default is PUT)
           self.callback_methods = { create: :post, update: :patch }.freeze
         end
 
         class_methods do
+          def fmrest_config
+            if fmrest_config_override
+              return FmRest.default_connection_settings.merge(fmrest_config_override, skip_validation: true)
+            end
+
+            FmRest.default_connection_settings
+          end
+
+          # Behaves similar to ActiveSupport's class_attribute, redefining the
+          # reader method so it can be inherited and overwritten in subclasses
+          #
+          def fmrest_config=(settings)
+            settings = ConnectionSettings.new(settings, skip_validation: true)
+
+            redefine_singleton_method(:fmrest_config) do
+              return settings.merge(fmrest_config_override, skip_validation: true) if fmrest_config_override
+              settings
+            end
+          end
+
+          # Allows overwriting some connection settings in a thread-local
+          # manner. Useful in the use case where you want to connect to the
+          # same database using different accounts (e.g. credentials provided
+          # by users in a web app context)
+          #
+          def fmrest_config_override=(settings)
+            Thread.current[fmrest_config_override_key] = settings
+          end
+
+          def fmrest_config_override
+            Thread.current[fmrest_config_override_key] || begin
+              superclass.fmrest_config_override
+            rescue NoMethodError
+              nil
+            end
+          end
+
+          def clear_fmrest_config_override
+            Thread.current[fmrest_config_override_key] = nil
+          end
+
+          def with_override(settings, &block)
+            Fiber.new do
+              begin
+                self.fmrest_config_override = settings
+                yield
+              ensure
+                self.clear_fmrest_config_override
+              end
+            end.resume
+          end
+
           def connection
             super || fmrest_connection
           end
@@ -47,26 +88,41 @@ module FmRest
           private
 
           def fmrest_connection
-            @fmrest_connection ||=
-              begin
-                config = ConnectionSettings.wrap(fmrest_config)
+            # NOTE: this method is intentionally unmemoized to prevent multiple
+            # threads using the same connection (whether that would be a real
+            # problem is not clear, but https://github.com/balvig/spyke/pull/63
+            # suggests it might).
+            #
+            # Instead, each call will create a new connection. This could
+            # probably be memoized with thread-local variables, but the
+            # memoization would also need to be invalidated any time
+            # .fmrest_config_override= is used on this or any parent class.
 
-                FmRest::V1.build_connection(config) do |conn|
-                  faraday_block.call(conn) if faraday_block
+            config = ConnectionSettings.wrap(fmrest_config)
 
-                  # Pass the class to SpykeFormatter's initializer so it can have
-                  # access to extra context defined in the model, e.g. a portal
-                  # where name of the portal and the attributes prefix don't match
-                  # and need to be specified as options to `portal`
-                  conn.use FmRest::Spyke::SpykeFormatter, self
+            FmRest::V1.build_connection(config) do |conn|
+              faraday_block.call(conn) if faraday_block
 
-                  conn.use FmRest::V1::TypeCoercer, config
+              # Pass the class to SpykeFormatter's initializer so it can have
+              # access to extra context defined in the model, e.g. a portal
+              # where name of the portal and the attributes prefix don't match
+              # and need to be specified as options to `portal`
+              conn.use FmRest::Spyke::SpykeFormatter, self
 
-                  # FmRest::Spyke::JsonParse expects symbol keys
-                  conn.response :json, parser_options: { symbolize_names: true }
-                end
-              end
+              conn.use FmRest::V1::TypeCoercer, config
+
+              # FmRest::Spyke::JsonParse expects symbol keys
+              conn.response :json, parser_options: { symbolize_names: true }
+            end
           end
+
+          def fmrest_config_override_key
+            :"#{object_id}.fmrest_config_override"
+          end
+        end
+
+        def fmrest_config
+          self.class.fmrest_config
         end
       end
     end

--- a/lib/fmrest/spyke/model/serialization.rb
+++ b/lib/fmrest/spyke/model/serialization.rb
@@ -76,7 +76,7 @@ module FmRest
         end
 
         def convert_datetime_timezone(dt)
-          case fmrest_config.fetch(:timezone, nil)
+          case fmrest_config.timezone
           when :utc, "utc"
             dt.new_offset(0)
           when :local, "local"

--- a/lib/fmrest/token_store.rb
+++ b/lib/fmrest/token_store.rb
@@ -2,5 +2,11 @@
 
 module FmRest
   module TokenStore
+    autoload :Base,         "fmrest/token_store/base"
+    autoload :Memory,       "fmrest/token_store/memory"
+    autoload :Null,         "fmrest/token_store/null"
+    autoload :ActiveRecord, "fmrest/token_store/active_record"
+    autoload :Moneta,       "fmrest/token_store/moneta"
+    autoload :Redis,        "fmrest/token_store/redis"
   end
 end

--- a/lib/fmrest/token_store/base.rb
+++ b/lib/fmrest/token_store/base.rb
@@ -10,15 +10,15 @@ module FmRest
       end
 
       def load(key)
-        raise "Not implemented"
+        raise NotImplementedError
       end
 
       def store(key, value)
-        raise "Not implemented"
+        raise NotImplementedError
       end
 
       def delete(key)
-        raise "Not implemented"
+        raise NotImplementedError
       end
     end
   end

--- a/lib/fmrest/v1.rb
+++ b/lib/fmrest/v1.rb
@@ -8,10 +8,6 @@ require "fmrest/v1/dates"
 
 module FmRest
   module V1
-    DEFAULT_DATE_FORMAT = "MM/dd/yyyy"
-    DEFAULT_TIME_FORMAT = "HH:mm:ss"
-    DEFAULT_TIMESTAMP_FORMAT = "#{DEFAULT_DATE_FORMAT} #{DEFAULT_TIME_FORMAT}"
-
     extend Connection
     extend Paths
     extend ContainerFields

--- a/lib/fmrest/v1.rb
+++ b/lib/fmrest/v1.rb
@@ -5,6 +5,7 @@ require "fmrest/v1/paths"
 require "fmrest/v1/container_fields"
 require "fmrest/v1/utils"
 require "fmrest/v1/dates"
+require "fmrest/v1/auth"
 
 module FmRest
   module V1
@@ -13,5 +14,10 @@ module FmRest
     extend ContainerFields
     extend Utils
     extend Dates
+    extend Auth
+
+    autoload :TokenSession, "fmrest/v1/token_session"
+    autoload :RaiseErrors, "fmrest/v1/raise_errors"
+    autoload :TypeCoercer, "fmrest/v1/type_coercer"
   end
 end

--- a/lib/fmrest/v1/auth.rb
+++ b/lib/fmrest/v1/auth.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module FmRest
+  module V1
+    module Auth
+      # Requests a token through basic auth
+      #
+      # @param connection [Faraday] the auth connection to use for
+      #   the request
+      # @return The token if successful
+      # @return `false` if authentication failed
+      def request_auth_token(connection = FmRest::V1.auth_connection)
+        request_auth_token!(connection)
+      rescue FmRest::APIError::AccountError
+        false
+      end
+
+      # Requests a token through basic auth, raising
+      # `FmRest::APIError::AccountError` if auth fails
+      #
+      # @param (see #request_auth_token)
+      # @return The token if successful
+      # @raise [FmRest::APIError::AccountError] if authentication failed
+      def request_auth_token!(connection = FmRest.V1.auth_connection)
+        resp = connection.post(V1.session_path)
+        resp.body["response"]["token"]
+      end
+    end
+  end
+end

--- a/lib/fmrest/v1/raise_errors.rb
+++ b/lib/fmrest/v1/raise_errors.rb
@@ -23,9 +23,11 @@ module FmRest
         402..499   => APIError::ParameterError,
         500..599   => APIError::ValidationError,
         800..899   => APIError::SystemError,
+        952        => APIError::InvalidToken,
+        953        => APIError::MaximumDataAPICallsExceeded,
         1200..1299 => APIError::ScriptError,
         1400..1499 => APIError::ODBCError
-      }
+      }.freeze
 
       def on_complete(env)
         # Sniff for either straight JSON parsing or Spyke's format

--- a/lib/fmrest/v1/token_session.rb
+++ b/lib/fmrest/v1/token_session.rb
@@ -10,7 +10,7 @@ module FmRest
     class TokenSession < Faraday::Middleware
       class NoSessionTokenSet < FmRest::Error; end
 
-      HEADER_KEY = "Authorization".freeze
+      HEADER_KEY = "Authorization"
       TOKEN_STORE_INTERFACE = [:load, :store, :delete].freeze
       LOGOUT_PATH_MATCHER = %r{\A(#{FmRest::V1::Connection::BASE_PATH}/[^/]+/sessions/)[^/]+\Z}.freeze
 
@@ -32,27 +32,37 @@ module FmRest
 
         @app.call(env).on_complete do |response_env|
           if response_env[:status] == 401 # Unauthorized
-            env[:body] = request_body
-            token_store.delete(token_store_key)
-            set_auth_header(env)
-            return @app.call(env)
+            delete_token_store_key
+
+            if @settings.autologin
+              env[:body] = request_body
+              set_auth_header(env)
+              return @app.call(env)
+            end
           end
         end
       end
 
       private
 
+      def delete_token_store_key
+        token_store.delete(token_store_key)
+        # Sometimes we may want to pass the :token in settings manually, and
+        # refrain from passing a :username. In that case the call to
+        # #token_store_key above would fail as it tries to fetch :username, so
+        # we purposely ignore that error.
+      rescue FmRest::ConnectionSettings::MissingSetting
+      end
+
       def handle_logout(env)
-        token = token_store.load(token_store_key)
+        token = @settings.token? ? @settings.token : token_store.load(token_store_key)
 
         raise NoSessionTokenSet, "Couldn't send logout request because no session token was set" unless token
 
         env.url.path = env.url.path.gsub(LOGOUT_PATH_MATCHER, "\\1#{token}")
 
         @app.call(env).on_complete do |response_env|
-          if response_env[:status] == 200
-            token_store.delete(token_store_key)
-          end
+          delete_token_store_key if response_env[:status] == 200
         end
       end
 
@@ -65,32 +75,22 @@ module FmRest
         env.request_headers[HEADER_KEY] = "Bearer #{token}"
       end
 
-      # Tries to get an existing token from the token store,
+      # Uses the token given in connection settings if available,
+      # otherwisek tries to get an existing token from the token store,
       # otherwise requests one through basic auth,
       # otherwise raises an exception.
       #
       def token
+        return @settings.token if @settings.token?
+
         token = token_store.load(token_store_key)
         return token if token
 
-        if token = request_token
-          token_store.store(token_store_key, token)
-          return token
-        end
+        return nil unless @settings.autologin
 
-        # TODO: Make this a custom exception class
-        raise "Filemaker auth failed"
-      end
-
-      # Requests a token through basic auth
-      #
-      def request_token
-        resp = auth_connection.post do |req|
-          req.url V1.session_path
-          req.headers["Content-Type"] = "application/json"
-        end
-        return resp.body["response"]["token"] if resp.success?
-        false
+        token = V1.request_auth_token!(auth_connection)
+        token_store.store(token_store_key, token)
+        token
       end
 
       # The key to use to store a token, uses the format host:database:username
@@ -111,10 +111,13 @@ module FmRest
             if TOKEN_STORE_INTERFACE.all? { |method| token_store_option.respond_to?(method) }
               token_store_option
             elsif token_store_option.kind_of?(Class)
-              token_store_option.new
+              if token_store_option.respond_to?(:instance)
+                token_store_option.instance
+              else
+                token_store_option.new
+              end
             else
-              require "fmrest/token_store/memory"
-              TokenStore::Memory.new
+              FmRest::TokenStore::Memory.new
             end
           end
       end
@@ -124,16 +127,7 @@ module FmRest
       end
 
       def auth_connection
-        @auth_connection ||= V1.base_connection(@settings) do |conn|
-          conn.basic_auth @settings.username!, @settings.password!
-
-          if @settings.log
-            conn.response :logger, nil, bodies: true, headers: true
-          end
-
-          conn.response :json
-          conn.adapter Faraday.default_adapter
-        end
+        @auth_connection ||= V1.auth_connection(@settings)
       end
     end
   end

--- a/lib/fmrest/v1/token_session.rb
+++ b/lib/fmrest/v1/token_session.rb
@@ -99,9 +99,9 @@ module FmRest
         @token_store_key ||=
           begin
             # Strip the host part to just the hostname (i.e. no scheme or port)
-            host = @settings.host
+            host = @settings.host!
             host = URI(host).hostname if host =~ /\Ahttps?:\/\//
-            "#{host}:#{@settings.database}:#{@settings.username}"
+            "#{host}:#{@settings.database!}:#{@settings.username!}"
           end
       end
 
@@ -125,7 +125,7 @@ module FmRest
 
       def auth_connection
         @auth_connection ||= V1.base_connection(@settings) do |conn|
-          conn.basic_auth @settings.username, @settings.password
+          conn.basic_auth @settings.username!, @settings.password!
 
           if @settings.log
             conn.response :logger, nil, bodies: true, headers: true

--- a/lib/fmrest/v1/type_coercer.rb
+++ b/lib/fmrest/v1/type_coercer.rb
@@ -13,8 +13,8 @@ module FmRest
       COERCE_FULL = [:full, "full"].freeze
 
       # @param app [#call]
-      # @param options [Hash]
-      def initialize(app, options = FmRest.default_connection_settings)
+      # @param options [FmRest::ConnectionSettings]
+      def initialize(app, options)
         super(app)
         @options = options
       end
@@ -112,15 +112,15 @@ module FmRest
       end
 
       def date_fm_format
-        @options[:date_format] || DEFAULT_DATE_FORMAT
+        @options.date_format
       end
 
       def timestamp_fm_format
-        @options[:timestamp_format] || DEFAULT_TIMESTAMP_FORMAT
+        @options.timestamp_format
       end
 
       def time_fm_format
-        @options[:time_format] || DEFAULT_TIME_FORMAT
+        @options.time_format
       end
 
       def date_strptime_format
@@ -179,11 +179,11 @@ module FmRest
       end
 
       def local_timezone?
-        @local_timezone ||= @options.fetch(:timezone, nil).try(:to_sym) == :local
+        @local_timezone ||= @options.timezone.try(:to_sym) == :local
       end
 
       def coerce_dates
-        @options.fetch(:coerce_dates, false)
+        @options.coerce_dates
       end
 
       alias_method :enabled?, :coerce_dates

--- a/lib/fmrest/v1/type_coercer.rb
+++ b/lib/fmrest/v1/type_coercer.rb
@@ -13,10 +13,10 @@ module FmRest
       COERCE_FULL = [:full, "full"].freeze
 
       # @param app [#call]
-      # @param options [FmRest::ConnectionSettings]
-      def initialize(app, options)
+      # @param settings [FmRest::ConnectionSettings]
+      def initialize(app, settings)
         super(app)
-        @options = options
+        @settings = settings
       end
 
       def on_complete(env)
@@ -112,15 +112,15 @@ module FmRest
       end
 
       def date_fm_format
-        @options.date_format
+        @settings.date_format
       end
 
       def timestamp_fm_format
-        @options.timestamp_format
+        @settings.timestamp_format
       end
 
       def time_fm_format
-        @options.time_format
+        @settings.time_format
       end
 
       def date_strptime_format
@@ -179,11 +179,11 @@ module FmRest
       end
 
       def local_timezone?
-        @local_timezone ||= @options.timezone.try(:to_sym) == :local
+        @local_timezone ||= @settings.timezone.try(:to_sym) == :local
       end
 
       def coerce_dates
-        @options.coerce_dates
+        @settings.coerce_dates
       end
 
       alias_method :enabled?, :coerce_dates

--- a/lib/fmrest/v1/utils.rb
+++ b/lib/fmrest/v1/utils.rb
@@ -72,7 +72,6 @@ module FmRest
         params
       end
 
-
       private
 
       def convert_script_arguments(script_arguments, suffix = nil)

--- a/spec/fmrest/connection_settings_spec.rb
+++ b/spec/fmrest/connection_settings_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe FmRest::ConnectionSettings do
     end
 
     it "validates missing properties" do
-      expect { described_class.new({}) }.to raise_error(FmRest::ConnectionSettings::MissingSetting, /`host', `database', `username'/)
+      expect { described_class.new({}) }.to raise_error(FmRest::ConnectionSettings::MissingSetting, /`host', `database'/)
+      expect { described_class.new({host: "foo", database: "bar"}) }.to raise_error(FmRest::ConnectionSettings::MissingSetting, /`username' or `token'/)
     end
 
     it "doesn't validate if skip_validation: true is given" do
@@ -67,10 +68,19 @@ RSpec.describe FmRest::ConnectionSettings do
       expect(subject[:date_format]).to eq(FmRest::ConnectionSettings::DEFAULT_DATE_FORMAT)
       expect(subject[:time_format]).to eq(FmRest::ConnectionSettings::DEFAULT_TIME_FORMAT)
       expect(subject[:timestamp_format]).to eq(FmRest::ConnectionSettings::DEFAULT_TIMESTAMP_FORMAT)
+      expect(subject[:autologin]).to eq(true)
+    end
+
+    it "returns the requested property's default only if it was not given explicitly" do
+      config = described_class.new(host: "host", username: "bob", database: "xyz")
+      expect(config[:autologin]).to eq(true)
+
+      config = described_class.new(host: "host", username: "bob", database: "xyz", autologin: false)
+      expect(config[:autologin]).to eq(false)
     end
 
     it "raises an exception if the requested property is not recognized" do
-      expect { subject[:peekaboo] }.to raise_error(ArgumentError, "Unknown property `peekaboo'")
+      expect { subject[:peekaboo] }.to raise_error(ArgumentError, "Unknown setting `peekaboo'")
     end
   end
 

--- a/spec/fmrest/connection_settings_spec.rb
+++ b/spec/fmrest/connection_settings_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe FmRest::ConnectionSettings do
     end
 
     it "validates missing properties" do
-      expect { described_class.new({}) }.to raise_error(FmRest::ConnectionSettings::ValidationError, /`host', `database', `username', `password'/)
+      expect { described_class.new({}) }.to raise_error(FmRest::ConnectionSettings::MissingSetting, /`host', `database', `username'/)
     end
 
     it "doesn't validate if skip_validation: true is given" do
-      expect { described_class.new({}, skip_validation: true) }.to_not raise_error(FmRest::ConnectionSettings::ValidationError)
+      expect { described_class.new({}, skip_validation: true) }.to_not raise_error(FmRest::ConnectionSettings::MissingSetting)
     end
 
     it "creates a copy if given a ConnectionSettings object" do

--- a/spec/fmrest/connection_settings_spec.rb
+++ b/spec/fmrest/connection_settings_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe FmRest::ConnectionSettings do
     end
   end
 
+  describe "#merge" do
+    it "creates a new ConnectionSettings instance with properties merged with the passed settings" do
+      merged = subject.merge(username: "bobby")
+      expect(merged.username).to eq("bobby")
+      expect(merged.password).to eq("secret")
+    end
+  end
+
   FmRest::ConnectionSettings::PROPERTIES.each do |p|
     describe "##{p}" do
       it { expect(subject.send(p)).to eq(subject[p]) }

--- a/spec/fmrest/connection_settings_spec.rb
+++ b/spec/fmrest/connection_settings_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FmRest::ConnectionSettings do
+  let(:basic) do
+    {
+      host: "host.somewhere",
+      username: "bob",
+      password: "secret",
+      database: "xyz"
+    }
+  end
+
+  subject { described_class.new(basic) }
+
+  describe ".wrap" do
+    it "returns the given argument if it's already a ConnectionSettings instance" do
+      expect(described_class.wrap(subject)).to equal(subject)
+    end
+
+    it "validates the given ConnectionSettings instance" do
+      expect(subject).to receive(:validate)
+      described_class.wrap(subject)
+    end
+
+    it "doesn't validate the given ConnectionSettings instance if skip_validation: true is given" do
+      expect(subject).to_not receive(:validate)
+      described_class.wrap(subject, skip_validation: true)
+    end
+
+    it "returns a new ConnectionSettings instance if given a hash" do
+      expect(described_class.wrap(basic)).to be_a(described_class)
+    end
+
+    it "passes the skip_validation option to .new" do
+      expect(described_class).to receive(:new).with(anything, skip_validation: true)
+      described_class.wrap({}, skip_validation: true)
+    end
+  end
+
+  describe "#initialize" do
+    it "normalizes alias properties" do
+      settings_hash = basic
+      settings_hash[:account_name] = settings_hash.delete(:username)
+      expect(described_class.new(settings_hash).username).to eq("bob")
+    end
+
+    it "validates missing properties" do
+      expect { described_class.new({}) }.to raise_error(FmRest::ConnectionSettings::ValidationError, /`host', `database', `username', `password'/)
+    end
+
+    it "doesn't validate if skip_validation: true is given" do
+      expect { described_class.new({}, skip_validation: true) }.to_not raise_error(FmRest::ConnectionSettings::ValidationError)
+    end
+
+    it "creates a copy if given a ConnectionSettings object" do
+      settings = described_class.new(subject)
+      expect(settings.username).to eq(subject.username)
+    end
+  end
+
+  describe "#[]" do
+    it "returns the requested property or its default, indifferent of access key (symbol or string)" do
+      expect(subject[:username]).to eq("bob")
+      expect(subject["username"]).to eq("bob")
+      expect(subject[:date_format]).to eq(FmRest::ConnectionSettings::DEFAULT_DATE_FORMAT)
+      expect(subject[:time_format]).to eq(FmRest::ConnectionSettings::DEFAULT_TIME_FORMAT)
+      expect(subject[:timestamp_format]).to eq(FmRest::ConnectionSettings::DEFAULT_TIMESTAMP_FORMAT)
+    end
+
+    it "raises an exception if the requested property is not recognized" do
+      expect { subject[:peekaboo] }.to raise_error(ArgumentError, "Unknown property `peekaboo'")
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a new hash with the non-default properties" do
+      settings = described_class.new(basic.merge(
+        date_format: FmRest::ConnectionSettings::DEFAULT_DATE_FORMAT,
+        ssl: nil
+      ))
+      expect(settings.to_h).to eq(basic)
+    end
+  end
+
+  FmRest::ConnectionSettings::PROPERTIES.each do |p|
+    describe "##{p}" do
+      it { expect(subject.send(p)).to eq(subject[p]) }
+    end
+
+    describe "##{p}?" do
+      it { expect(subject.send("#{p}?")).to eq(!!subject[p]) }
+    end
+  end
+end

--- a/spec/fmrest/v1/auth_spec.rb
+++ b/spec/fmrest/v1/auth_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FmRest::V1::Auth do
+  let(:extendee) { Object.new.tap { |obj| obj.extend(described_class) } }
+
+  let(:connection) { connection = FmRest::V1.auth_connection(FMREST_DUMMY_CONFIG) }
+
+  describe "#request_auth_token!" do
+    it "returns the token when successful" do
+      stub_request(:post, fm_url + "/sessions").to_return_fm(token: "imatoken")
+      expect(extendee.request_auth_token!(connection)).to eq("imatoken")
+    end
+
+    it "raises an exception when auth failed" do
+      stub_request(:post, fm_url + "/sessions").to_return_fm(214)
+      expect { extendee.request_auth_token!(connection) }.to raise_error(FmRest::APIError::AccountError)
+    end
+  end
+
+  describe "#request_auth_token" do
+    it "returns the token when successful" do
+      stub_request(:post, fm_url + "/sessions").to_return_fm(token: "imatoken")
+      expect(extendee.request_auth_token(connection)).to eq("imatoken")
+    end
+
+    it "returns false when auth failed" do
+      stub_request(:post, fm_url + "/sessions").to_return_fm(214)
+      expect(extendee.request_auth_token(connection)).to eq(false)
+    end
+  end
+end

--- a/spec/fmrest/v1/connection_spec.rb
+++ b/spec/fmrest/v1/connection_spec.rb
@@ -3,17 +3,19 @@ require "spec_helper"
 RSpec.describe FmRest::V1::Connection do
   let(:extendee) { Object.new.tap { |obj| obj.extend(described_class) } }
 
-  describe "#base_connection" do
-    context "when not given proper :host or :database options" do
-      it "raises a KeyError" do
-        expect { extendee.base_connection(host: "example.com") }.to raise_error(KeyError)
-        expect { extendee.base_connection(database: "Test DB") }.to raise_error(KeyError)
-      end
-    end
+  let(:conn_settings) do
+    {
+      host: "example.com",
+      database: "Test DB",
+      username: "bob",
+      password: "secret"
+    }
+  end
 
+  describe "#base_connection" do
     context "when passed proper :host and :database options" do
       it "returns a Faraday::Connection with the right URL set" do
-        connection = extendee.base_connection(host: "example.com", database: "Test DB")
+        connection = extendee.base_connection(conn_settings)
         expect(connection).to be_a(Faraday::Connection)
         expect(connection.url_prefix.to_s).to eq("https://example.com/fmi/data/v1/databases/Test%20DB/")
       end
@@ -21,12 +23,12 @@ RSpec.describe FmRest::V1::Connection do
       it "passes the given block to the Faraday constructor" do
         dbl = double
         expect(dbl).to receive(:foo) { true }
-        extendee.base_connection(host: "example.com", database: "Test DB") { dbl.foo }
+        extendee.base_connection(conn_settings) { dbl.foo }
       end
 
       context "when passed :ssl and :proxy options" do
         it "returns a Faraday::Connection with ssl and proxy options set" do
-          connection = extendee.base_connection(host: "example.com", database: "Test DB", ssl: { verify: false }, proxy: "https://foo.bar")
+          connection = extendee.base_connection(conn_settings.merge(ssl: { verify: false }, proxy: "https://foo.bar"))
           expect(connection.ssl.verify).to eq(false)
           expect(connection.proxy.uri.to_s).to eq("https://foo.bar")
         end
@@ -35,12 +37,8 @@ RSpec.describe FmRest::V1::Connection do
   end
 
   describe "#build_connection" do
-    let :conn_options do
-      { host: "example.com", database: "Test DB" }
-    end
-
     let :connection do
-      extendee.build_connection(conn_options)
+      extendee.build_connection(conn_settings)
     end
 
     it "returns a Faraday::Connection that uses RaiseErrors" do
@@ -67,14 +65,20 @@ RSpec.describe FmRest::V1::Connection do
 
     context "with a block given" do
       it "doesn't return a Faraday::Connection that parses responses as JSON" do
-        connection = extendee.build_connection(conn_options) {}
+        connection = extendee.build_connection(conn_settings) {}
         expect(connection.builder.handlers).to_not include(FaradayMiddleware::ParseJson)
       end
     end
 
     context "with log: true" do
-      let :conn_options do
-        { host: "example.com", database: "Test DB", log: true }
+      let :conn_settings do
+        {
+          host: "example.com",
+          database: "Test DB",
+          username: "bob",
+          password: "secret",
+          log:      true
+        }
       end
 
       it "uses the logger Faraday middleware" do

--- a/spec/fmrest/v1/raise_errors_spec.rb
+++ b/spec/fmrest/v1/raise_errors_spec.rb
@@ -105,6 +105,22 @@ RSpec.describe FmRest::V1::RaiseErrors do
       end
     end
 
+    context "with message code 952" do
+      let(:error_code) { 952 }
+
+      it "raises a InvalidToken" do
+        expect { faraday.post("/") }.to raise_error(FmRest::APIError::InvalidToken)
+      end
+    end
+
+    context "with message code 953" do
+      let(:error_code) { 953 }
+
+      it "raises a MaximumDataAPICallsExceeded" do
+        expect { faraday.post("/") }.to raise_error(FmRest::APIError::MaximumDataAPICallsExceeded)
+      end
+    end
+
     context "with message code between 1200-1299" do
       let(:error_code) { 1200 }
 

--- a/spec/fmrest/v1/token_session_spec.rb
+++ b/spec/fmrest/v1/token_session_spec.rb
@@ -3,6 +3,7 @@ require "fmrest/token_store/memory"
 
 RSpec.describe FmRest::V1::TokenSession do
   let(:token_store) { FmRest::TokenStore::Memory.new }
+  let(:config_token) { nil }
 
   let(:hostname) { "stub" }
 
@@ -15,6 +16,7 @@ RSpec.describe FmRest::V1::TokenSession do
       username:    "bobby",
       password:    "cubictrousers",
       token_store: token_store,
+      token:       config_token,
       autologin:   autologin
     }
   end
@@ -74,6 +76,16 @@ RSpec.describe FmRest::V1::TokenSession do
         it "does not request a new token" do
           stub_request(:get, "https://#{hostname}/").to_return_fm
           faraday.get("/")
+          expect(@session_request).to_not have_been_requested
+        end
+      end
+
+      context "when a token is given in connection settings" do
+        let(:config_token) { new_token }
+
+        it "uses that token instead of requesting one" do
+          faraday.get("/")
+          expect(@retry_request).to have_been_requested.once
           expect(@session_request).to_not have_been_requested
         end
       end

--- a/spec/fmrest/v1/type_coercer_spec.rb
+++ b/spec/fmrest/v1/type_coercer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FmRest::V1::TypeCoercer do
 
   let :faraday do
     Faraday.new("https://#{hostname}") do |conn|
-      conn.use described_class, config
+      conn.use described_class, FmRest::ConnectionSettings.new(config, skip_validation: true)
       conn.response :json
       conn.adapter Faraday.default_adapter
     end

--- a/spec/fmrest/v1/type_coercer_spec.rb
+++ b/spec/fmrest/v1/type_coercer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FmRest::V1::TypeCoercer do
   let(:hostname) { "stub" }
 
   let(:coerce_dates) { true }
-  let(:date_format) { nil }
+  let(:date_format) { FmRest::ConnectionSettings::DEFAULT_DATE_FORMAT }
   let(:timezone) { nil }
 
   let(:config) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 
 require "spyke"
 require "fmrest"
+require "fmrest/token_store/memory"
 require "fmrest/spyke"
 require "pry-byebug"
 
@@ -16,13 +17,9 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  # Reset fixture models' connections
-  config.after(:all) do
-    if defined?(FixtureBase)
-      [FixtureBase, *FixtureBase.descendants].each do |klass|
-        klass.instance_variable_set(:@fmrest_connection, nil)
-      end
-    end
+  config.before(:all) do
+    # Keep a same instance of the token store for all examples in a group
+    FmRest.token_store = FmRest::TokenStore::Memory.new
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 
 require "spyke"
@@ -20,6 +22,15 @@ RSpec.configure do |config|
   config.before(:all) do
     # Keep a same instance of the token store for all examples in a group
     FmRest.token_store = FmRest::TokenStore::Memory.new
+  end
+
+  # Reset fixture models' connections
+  config.after(:all) do
+    if defined?(FixtureBase)
+      [FixtureBase, *FixtureBase.descendants].each do |klass|
+        klass.instance_variable_set(:@fmrest_connection, nil)
+      end
+    end
   end
 end
 

--- a/spec/spyke/base_spec.rb
+++ b/spec/spyke/base_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FmRest::Spyke::Base do
       end
 
       it "takes an argument and assigns it to fmrest_config" do
-        expect(subclass.fmrest_config).to eq(host: "example.com")
+        expect(subclass.fmrest_config.to_h).to eq(host: "example.com")
       end
     end
 

--- a/spec/spyke/base_spec.rb
+++ b/spec/spyke/base_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe FmRest::Spyke::Base do
       end
 
       it "doesn't set fmrest_config" do
-        expect(subclass.fmrest_config).to eq(FmRest.default_connection_settings)
+        dummy_settings = double("EmptyConnectionSettings")
+        allow(FmRest).to receive(:default_connection_settings).and_return(dummy_settings)
+        expect(subclass.fmrest_config).to eq(dummy_settings)
       end
     end
   end

--- a/spec/spyke/model/auth_spec.rb
+++ b/spec/spyke/model/auth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "fixtures/pirates"

--- a/spec/spyke/model/auth_spec.rb
+++ b/spec/spyke/model/auth_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 require "fixtures/pirates"
 
 RSpec.describe FmRest::Spyke::Model::Auth do
-  after(:all) do
-    Ship.instance_variable_set(:@fmrest_connection, nil)
-  end
-
   describe ".logout!" do
     context "with a token set" do
       let(:token) { "TOKEN" }

--- a/spec/spyke/model/connection_spec.rb
+++ b/spec/spyke/model/connection_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe FmRest::Spyke::Model::Connection do
       expect(subject.builder.handlers).to include(FaradayMiddleware::ParseJson)
     end
 
-    it "recycles the same connection when there's no override" do
+    it "recycles the same connection when there's no overlay" do
       expect(FixtureBase.connection).to equal(FixtureBase.connection)
     end
 
-    it "returns a new connection each time if there's an override" do
-      FixtureBase.fmrest_config_override = { host: "foo.bar.qux" }
+    it "returns a new connection each time if there's an overlay" do
+      FixtureBase.fmrest_config_overlay = { host: "foo.bar.qux" }
       expect(FixtureBase.connection).to_not equal(FixtureBase.connection)
-      FixtureBase.clear_fmrest_config_override
+      FixtureBase.clear_fmrest_config_overlay
     end
   end
 
@@ -94,24 +94,24 @@ RSpec.describe FmRest::Spyke::Model::Connection do
     end
   end
 
-  describe ".fmrest_config_override" do
-    after(:each) { FixtureBase.clear_fmrest_config_override }
+  describe ".fmrest_config_overlay" do
+    after(:each) { FixtureBase.clear_fmrest_config_overlay }
 
-    it "overrides the given properties on .fmrest_config" do
-      FixtureBase.fmrest_config_override = { username: "alice" }
+    it "overlays the given properties on .fmrest_config" do
+      FixtureBase.fmrest_config_overlay = { username: "alice" }
       expect(FixtureBase.fmrest_config.username).to eq("alice")
     end
 
-    it "inherits overrides from parent classes" do
-      FixtureBase.fmrest_config_override = { username: "alice" }
+    it "inherits overlays from parent classes" do
+      FixtureBase.fmrest_config_overlay = { username: "alice" }
       child = Class.new(FixtureBase)
       expect(child.fmrest_config.username).to eq("alice")
     end
   end
 
-  describe ".with_override" do
-    it "overrides the given properties within the passed block" do
-      FixtureBase.with_override(username: "nikki") do
+  describe ".with_overlay" do
+    it "overlays the given properties within the passed block" do
+      FixtureBase.with_overlay(username: "nikki") do
         expect(FixtureBase.fmrest_config.username).to eq("nikki")
       end
 

--- a/spec/spyke/model/connection_spec.rb
+++ b/spec/spyke/model/connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "fixtures/base"
@@ -32,6 +34,16 @@ RSpec.describe FmRest::Spyke::Model::Connection do
 
     it "uses the ParseJson middleware" do
       expect(subject.builder.handlers).to include(FaradayMiddleware::ParseJson)
+    end
+
+    it "recycles the same connection when there's no override" do
+      expect(FixtureBase.connection).to equal(FixtureBase.connection)
+    end
+
+    it "returns a new connection each time if there's an override" do
+      FixtureBase.fmrest_config_override = { host: "foo.bar.qux" }
+      expect(FixtureBase.connection).to_not equal(FixtureBase.connection)
+      FixtureBase.clear_fmrest_config_override
     end
   end
 

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 require "support/webmock"
 require "uri"
 
 module RequestStubs
   def fm_url(host: FMREST_DUMMY_CONFIG[:host], database: FMREST_DUMMY_CONFIG[:database], layout: nil, id: nil)
-    "https://#{host}/fmi/data/v1/databases/#{URI.escape(database)}".tap do |url|
+    String.new("https://#{host}/fmi/data/v1/databases/#{URI.escape(database)}").tap do |url|
       if layout
         url << "/layouts/#{URI.escape(layout)}"
         url << "/records/#{id}" if id
       end
+
+      url.freeze
     end
   end
 


### PR DESCRIPTION
This adds the ability to override some connection settings in `FmRest::Spyke` models in a thread-local way, meaning in the context of a web app one could do:

```ruby
# (inside a controller)

def index
  # session hash already populated with FM credentials
  MyModel.fmrest_config_overlay = { username: session[:fm_username], password: session[:fm_password] }

  # Do stuff here... the FM connection will use the session's credentials
  # without affecting the connection settings for other threads/requests
end
```