### PR TITLE
Replace obsolete URI.escape with URI.encode_www_form_component.

### DIFF
--- a/lib/fmrest/v1/connection.rb
+++ b/lib/fmrest/v1/connection.rb
@@ -74,8 +74,10 @@ module FmRest
         faraday_options[:ssl] = options[:ssl] if options.key?(:ssl)
         faraday_options[:proxy] = options[:proxy] if options.key?(:proxy)
 
+        database = URI.encode_www_form_component(options.fetch(:database))
+
         Faraday.new(
-          "#{scheme}://#{host}#{BASE_PATH}/#{URI.escape(options.fetch(:database))}/".freeze,
+          "#{scheme}://#{host}#{BASE_PATH}/#{database}/".freeze,
           faraday_options,
           &block
         )

--- a/spec/fmrest/v1/connection_spec.rb
+++ b/spec/fmrest/v1/connection_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FmRest::V1::Connection do
       it "returns a Faraday::Connection with the right URL set" do
         connection = extendee.base_connection(host: "example.com", database: "Test DB")
         expect(connection).to be_a(Faraday::Connection)
-        expect(connection.url_prefix.to_s).to eq("https://example.com/fmi/data/v1/databases/Test%20DB/")
+        expect(connection.url_prefix.to_s).to eq("https://example.com/fmi/data/v1/databases/Test+DB/")
       end
 
       it "passes the given block to the Faraday constructor" do

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -3,9 +3,9 @@ require "uri"
 
 module RequestStubs
   def fm_url(host: FMREST_DUMMY_CONFIG[:host], database: FMREST_DUMMY_CONFIG[:database], layout: nil, id: nil)
-    "https://#{host}/fmi/data/v1/databases/#{URI.escape(database)}".tap do |url|
+    "https://#{host}/fmi/data/v1/databases/#{URI.encode_www_form_component(database)}".tap do |url|
       if layout
-        url << "/layouts/#{URI.escape(layout)}"
+        url << "/layouts/#{URI.encode_www_form_component(layout)}"
         url << "/records/#{id}" if id
       end
     end


### PR DESCRIPTION
First of all, thanks for this gem! It makes interacting with Filemaker joyful. :)

This PR fixes the `URI.escape is obsolete` warning messages in Ruby 2.7 by replacing it with `URI.encode_www_form_component`.

I've read up a bit about why and how, but it looks like the community is divided over how to escape what and where. A good, recent post about it can be [found here](https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string).

An alternative could be `CGI.escape`, but `URI.encode_www_form_component` seems to be more appropriate here.

Specs run as green as they originally came, so it should be good to go.