### PR TITLE
Unobstrusive record IDs

### DIFF
--- a/fmrest.gemspec
+++ b/fmrest.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "spyke"
+  spec.add_development_dependency "spyke", ">= 5.3.3"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "activerecord", ENV["ACTIVE_RECORD_VERSION"]

--- a/lib/fmrest/spyke/base.rb
+++ b/lib/fmrest/spyke/base.rb
@@ -5,19 +5,5 @@ module FmRest
     class Base < ::Spyke::Base
       include FmRest::Spyke::Model
     end
-
-    class << self
-      def Base(config = nil)
-        warn "[DEPRECATION] Inheriting from `FmRest::Spyke::Base(config)` is deprecated and will be removed, inherit from `FmRest::Spyke::Base` (without arguments) and use `fmrest_config=` instead"
-
-        if config
-          return Class.new(::FmRest::Spyke::Base) do
-                   self.fmrest_config = config
-                 end
-        end
-
-        ::FmRest::Spyke::Base
-      end
-    end
   end
 end

--- a/lib/fmrest/spyke/container_field.rb
+++ b/lib/fmrest/spyke/container_field.rb
@@ -42,7 +42,7 @@ module FmRest
           )
 
         # Update mod id on record
-        @base.mod_id = response.body[:data][:mod_id]
+        @base.__mod_id = response.body[:data][:__mod_id]
 
         true
       end
@@ -52,7 +52,7 @@ module FmRest
       # @param repetition [Integer]
       # @return [String] the path for uploading a file to the container
       def upload_path(repetition)
-        FmRest::V1.container_field_path(@base.class.layout, @base.id, name, repetition)
+        FmRest::V1.container_field_path(@base.class.layout, @base.__record_id, name, repetition)
       end
     end
   end

--- a/lib/fmrest/spyke/model.rb
+++ b/lib/fmrest/spyke/model.rb
@@ -18,7 +18,7 @@ module FmRest
       extend ::ActiveSupport::Concern
 
       include Connection
-      include Uri
+      include URI
       include RecordID
       include Attributes
       include Serialization

--- a/lib/fmrest/spyke/model.rb
+++ b/lib/fmrest/spyke/model.rb
@@ -2,6 +2,7 @@
 
 require "fmrest/spyke/model/connection"
 require "fmrest/spyke/model/uri"
+require "fmrest/spyke/model/record_id"
 require "fmrest/spyke/model/attributes"
 require "fmrest/spyke/model/serialization"
 require "fmrest/spyke/model/associations"
@@ -18,6 +19,7 @@ module FmRest
 
       include Connection
       include Uri
+      include RecordID
       include Attributes
       include Serialization
       include Associations
@@ -26,11 +28,6 @@ module FmRest
       include GlobalFields
       include Http
       include Auth
-
-      included do
-        # @return [Integer] the record's modId
-        attr_accessor :mod_id
-      end
     end
   end
 end

--- a/lib/fmrest/spyke/model/associations.rb
+++ b/lib/fmrest/spyke/model/associations.rb
@@ -5,6 +5,8 @@ require "fmrest/spyke/portal"
 module FmRest
   module Spyke
     module Model
+      # This module adds portal support to Spyke models.
+      #
       module Associations
         extend ::ActiveSupport::Concern
 
@@ -22,17 +24,18 @@ module FmRest
         end
 
         class_methods do
-          # Based on +has_many+, but creates a special Portal association
+          # Based on `has_many`, but creates a special Portal association
           # instead.
           #
-          # Custom options:
+          # @option :portal_key [String] The key used for the portal in the FM
+          #   Data JSON portalData
+          # @option :attribute_prefix [String] The prefix used for portal
+          #   attributes in the FM Data JSON
           #
-          # * <tt>:portal_key</tt> - The key used for the portal in the FM Data JSON portalData.
-          # * <tt>:attribute_prefix</tt> - The prefix used for portal attributes in the FM Data JSON.
-          #
-          # Example:
-          #
-          #   has_portal :jobs, portal_key: "JobsTable", attribute_prefix: "Job"
+          # @example
+          #   class Person < FmRest::Spyke::Base
+          #     has_portal :jobs, portal_key: "JobsTable", attribute_prefix: "Job"
+          #   end
           #
           def has_portal(name, options = {})
             create_association(name, Portal, options)
@@ -47,9 +50,8 @@ module FmRest
           end
         end
 
-        # Override Spyke's association reader to keep a cache of loaded
-        # portals. Spyke's default behavior is to reload the association
-        # each time.
+        # Spyke override -- Keep a cache of loaded portals. Spyke's default
+        # behavior is to reload the association each time.
         #
         def association(name)
           @loaded_portals ||= {}
@@ -64,6 +66,8 @@ module FmRest
           end
         end
 
+        # Spyke override -- Add portals awareness
+        #
         def reload(*_)
           super.tap { @loaded_portals = nil }
         end

--- a/lib/fmrest/spyke/model/attributes.rb
+++ b/lib/fmrest/spyke/model/attributes.rb
@@ -5,6 +5,10 @@ require "fmrest/spyke/model/orm"
 module FmRest
   module Spyke
     module Model
+      # Extends Spyke models with support for mapped attributes,
+      # `ActiveModel::Dirty` and forbidden attributes (e.g. Rails'
+      # `params.permit`).
+      #
       module Attributes
         extend ::ActiveSupport::Concern
 
@@ -33,10 +37,12 @@ module FmRest
         end
 
         class_methods do
+          # Spyke override
+          #
           # Similar to Spyke::Base.attributes, but allows defining attribute
           # methods that map to FM attributes with different names.
           #
-          # Example:
+          # @example
           #
           #   class Person < Spyke::Base
           #     include FmRest::Spyke::Model
@@ -58,9 +64,10 @@ module FmRest
 
           private
 
-          # Override Spyke::Base.new_or_return (private), called whenever
-          # loading records from the HTTP API, so we can reset dirty info on
-          # freshly loaded records
+          # Spyke override (private)
+          #
+          # Called whenever loading records from the HTTP API, so we can reset
+          # dirty info on freshly loaded records
           #
           # See: https://github.com/balvig/spyke/blob/master/lib/spyke/http.rb
           #
@@ -107,16 +114,20 @@ module FmRest
           end
         end
 
+        # Spyke override -- Adds AM::Dirty support
+        #
         def reload(*args)
           super.tap { |r| clear_changes_information }
         end
 
+        # Spyke override -- Adds AM::Dirty support
+        #
         def save(*args)
           super.tap { |r| changes_applied_after_save if r }
         end
 
-        # This adds support for forbidden attributes (i.e. Rails'
-        # params.permit, etc.)
+        # Spyke override -- Adds support for forbidden attributes (i.e. Rails'
+        # `params.permit`, etc.)
         #
         def attributes=(new_attributes)
           @spyke_attributes ||= ::Spyke::Attributes.new(scope.params)
@@ -134,7 +145,7 @@ module FmRest
           mapped_attributes.values_at(*changed)
         end
 
-        # Use known mapped_attributes for inspect
+        # Spyke override (private) -- Use known mapped_attributes for inspect
         #
         def inspect_attributes
           mapped_attributes.except(primary_key).map do |k, v|

--- a/lib/fmrest/spyke/model/attributes.rb
+++ b/lib/fmrest/spyke/model/attributes.rb
@@ -20,9 +20,6 @@ module FmRest
           # by Spyke
           self.attribute_method_matchers.shift
 
-          # ActiveModel::Dirty methods for id
-          define_attribute_method(:id)
-
           # Keep track of attribute mappings so we can get the FM field names
           # for changed attributes
           class_attribute :mapped_attributes, instance_writer: false, instance_predicate: false
@@ -88,8 +85,6 @@ module FmRest
           end
 
           def _fmrest_define_attribute(from, to)
-            raise ArgumentError, "attribute name `id' is reserved for the recordId" if from.to_s == "id"
-
             # We use a setter here instead of injecting the hash key/value pair
             # directly with #[]= so that we don't change the mapped_attributes
             # hash on the parent class. The resulting hash is frozen for the
@@ -112,11 +107,6 @@ module FmRest
           end
         end
 
-        def id=(value)
-          id_will_change! unless value == id
-          super
-        end
-
         def reload(*args)
           super.tap { |r| clear_changes_information }
         end
@@ -130,7 +120,8 @@ module FmRest
         #
         def attributes=(new_attributes)
           @spyke_attributes ||= ::Spyke::Attributes.new(scope.params)
-          use_setters(sanitize_for_mass_assignment(new_attributes)) if new_attributes && !new_attributes.empty?
+          return unless new_attributes && !new_attributes.empty?
+          use_setters(sanitize_for_mass_assignment(new_attributes))
         end
 
         private

--- a/lib/fmrest/spyke/model/attributes.rb
+++ b/lib/fmrest/spyke/model/attributes.rb
@@ -125,21 +125,11 @@ module FmRest
           super.tap { |r| changes_applied_after_save if r }
         end
 
-        # ActiveModel::Dirty since version 5.2 assumes that if there's an
-        # @attributes instance variable set we must be using ActiveRecord, so
-        # we override the instance variable name used by Spyke to avoid issues.
-        #
-        # TODO: Submit a pull request to Spyke so this isn't needed
-        #
-        def attributes
-          @_spyke_attributes
-        end
-
-        # In addition to the comments above on `attributes`, this also adds
-        # support for forbidden attributes
+        # This adds support for forbidden attributes (i.e. Rails'
+        # params.permit, etc.)
         #
         def attributes=(new_attributes)
-          @_spyke_attributes ||= ::Spyke::Attributes.new(scope.params)
+          @spyke_attributes ||= ::Spyke::Attributes.new(scope.params)
           use_setters(sanitize_for_mass_assignment(new_attributes)) if new_attributes && !new_attributes.empty?
         end
 

--- a/lib/fmrest/spyke/model/connection.rb
+++ b/lib/fmrest/spyke/model/connection.rb
@@ -3,6 +3,9 @@
 module FmRest
   module Spyke
     module Model
+      # This module provides methods for configuring the Farday connection for
+      # the model, as well as setting up the connection itself.
+      #
       module Connection
         extend ActiveSupport::Concern
 
@@ -10,7 +13,7 @@ module FmRest
           class_attribute :faraday_block, instance_accessor: false, instance_predicate: false
           class << self; private :faraday_block, :faraday_block=; end
 
-          # FM Data API expects PATCH for updates (Spyke's default is PUT)
+          # FM Data API expects PATCH for updates (Spyke uses PUT by default)
           self.callback_methods = { create: :post, update: :patch }.freeze
         end
 
@@ -23,8 +26,12 @@ module FmRest
             FmRest.default_connection_settings
           end
 
-          # Behaves similar to ActiveSupport's class_attribute, redefining the
-          # reader method so it can be inherited and overwritten in subclasses
+          # Sets the FileMaker connection settings for the model.
+          #
+          # Behaves similar to ActiveSupport's `class_attribute`, so it can be
+          # inherited and safely overwritten in subclasses.
+          #
+          # @param settings [Hash] The settings hash
           #
           def fmrest_config=(settings)
             settings = ConnectionSettings.new(settings, skip_validation: true)
@@ -36,15 +43,20 @@ module FmRest
             end
           end
 
-          # Allows overwriting some connection settings in a thread-local
+          # Allows overriding some connection settings in a thread-local
           # manner. Useful in the use case where you want to connect to the
           # same database using different accounts (e.g. credentials provided
-          # by users in a web app context)
+          # by users in a web app context).
+          #
+          # @param (see #fmrest_config=)
           #
           def fmrest_config_overlay=(settings)
             Thread.current[fmrest_config_overlay_key] = settings
           end
 
+          # @return [FmRest::ConnectionSettings] the connection settings
+          #   overlay if any is in use
+          #
           def fmrest_config_overlay
             Thread.current[fmrest_config_overlay_key] || begin
               superclass.fmrest_config_overlay
@@ -53,10 +65,23 @@ module FmRest
             end
           end
 
+          # Clears the connection settings overlay.
+          #
           def clear_fmrest_config_overlay
             Thread.current[fmrest_config_overlay_key] = nil
           end
 
+          # Runs a block of code in the context of the given connection
+          # settings without affecting the connection settings outside said
+          # block.
+          #
+          # @param (see #fmrest_config=)
+          #
+          # @example
+          #   Honeybee.with_overlay(username: "...", password: "...") do
+          #     Honeybee.query(...)
+          #   end
+          #
           def with_overlay(settings, &block)
             Fiber.new do
               begin
@@ -68,19 +93,22 @@ module FmRest
             end.resume
           end
 
+          # Spyke override -- Defaults to `fmrest_connection`
+          #
           def connection
             super || fmrest_connection
           end
 
           # Sets a block for injecting custom middleware into the Faraday
-          # connection. Example usage:
+          # connection.
           #
-          #     class MyModel < FmRest::Spyke::Base
-          #       faraday do |conn|
-          #         # Set up a custom logger for the model
-          #         conn.response :logger, MyApp.logger, bodies: true
-          #       end
+          # @example
+          #   class MyModel < FmRest::Spyke::Base
+          #     faraday do |conn|
+          #       # Set up a custom logger for the model
+          #       conn.response :logger, MyApp.logger, bodies: true
           #     end
+          #   end
           #
           def faraday(&block)
             self.faraday_block = block

--- a/lib/fmrest/spyke/model/container_fields.rb
+++ b/lib/fmrest/spyke/model/container_fields.rb
@@ -5,10 +5,25 @@ require "fmrest/spyke/container_field"
 module FmRest
   module Spyke
     module Model
+      # This module adds support for container fields.
+      #
       module ContainerFields
         extend ::ActiveSupport::Concern
 
         class_methods do
+          # Defines a container field on the model.
+          #
+          # @param name [Symbol] the name of the container field
+          #
+          # @option options [String] :field_name (nil) the name of the container
+          #   field in the FileMaker layout (only needed if it doesn't match
+          #   the name given)
+          #
+          # @example
+          #   class Honeybee < FmRest::Spyke::Base
+          #     container :photo, field_name: "Beehive Photo ID"
+          #   end
+          #
           def container(name, options = {})
             field_name = options[:field_name] || name
 

--- a/lib/fmrest/spyke/model/http.rb
+++ b/lib/fmrest/spyke/model/http.rb
@@ -15,6 +15,7 @@ module FmRest
           # execution results after a save, etc.
 
 
+          # Spyke overwrite
           def request(*args)
             super.tap do |r|
               Thread.current[last_request_metadata_key] = r.metadata
@@ -31,6 +32,26 @@ module FmRest
             "#{to_s}.last_request_metadata"
           end
         end
+      end
+
+      # Spyke overwrite
+      def uri
+        ::Spyke::Path.new(@uri_template, fmrest_uri_attributes) if @uri_template
+      end
+
+      private
+
+      # Spyke overwrite
+      def resolve_path_from_action(action)
+        case action
+        when Symbol then uri.join(action)
+        when String then ::Spyke::Path.new(action, fmrest_uri_attributes)
+        else uri
+        end
+      end
+
+      def fmrest_uri_attributes
+        persisted? ? { __record_id: record_id } : attributes.slice(:__record_id)
       end
     end
   end

--- a/lib/fmrest/spyke/model/orm.rb
+++ b/lib/fmrest/spyke/model/orm.rb
@@ -106,6 +106,16 @@ module FmRest
 
             scope.where(where_options)
           end
+
+          # Spyke override
+          def destroy(id = nil)
+            new(__record_id: id).destroy
+          end
+        end
+
+        # Spyke override
+        def persisted?
+          record_id?
         end
 
         # Overwrite Spyke's save to provide a number of features:
@@ -152,9 +162,9 @@ module FmRest
         def reload(options = {})
           scope = self.class
           scope = scope.script(options[:script]) if options.has_key?(:script)
-          reloaded = scope.find(id)
+          reloaded = scope.find(record_id)
           self.attributes = reloaded.attributes
-          self.mod_id = reloaded.mod_id
+          self.__mod_id = reloaded.mod_id
         end
 
         # ActiveModel 5+ implements this method, so we only needed if we're in

--- a/lib/fmrest/spyke/model/record_id.rb
+++ b/lib/fmrest/spyke/model/record_id.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "fmrest/spyke/model/orm"
+
+module FmRest
+  module Spyke
+    module Model
+      module RecordID
+        extend ::ActiveSupport::Concern
+
+        included do
+          # @return [Integer] the record's recordId
+          attr_accessor :__record_id
+          alias_method :record_id, :__record_id
+          alias_method :id, :__record_id
+
+          # @return [Integer] the record's modId
+          attr_accessor :__mod_id
+          alias_method :mod_id, :__mod_id
+
+          # Get rid of Spyke's id= setter method, as we'll be using __record_id=
+          # instead
+          undef_method :id=
+
+          # Tell Spyke that we want __record_id as the PK
+          self.primary_key = :__record_id
+        end
+
+        def record_id?
+          record_id.present?
+        end
+
+        def inspect
+          "#<#{self.class} record_id: #{record_id.inspect} #{inspect_attributes}>"
+        end
+
+        private
+
+        # Spyke Override
+        def conflicting_ids?(attributes)
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/fmrest/spyke/model/record_id.rb
+++ b/lib/fmrest/spyke/model/record_id.rb
@@ -1,10 +1,20 @@
 # frozen_string_literal: true
 
-require "fmrest/spyke/model/orm"
-
 module FmRest
   module Spyke
     module Model
+      # Modifies Spyke models to use `__record_id` instead of `id` as the
+      # "primary key" method, so that we can map a model class to a FM layout
+      # with a field named `id` without clobbering it.
+      #
+      # The `id` reader method still maps to the record ID for backwards
+      # compatibility and because Spyke hardcodes its use at various points
+      # through its codebase, but it can be safely overwritten (e.g. to map to
+      # a FM field).
+      #
+      # The recommended way to deal with a layout that maps an `id` attribute
+      # is to remap it in the model to something else, e.g. `unique_id`.
+      #
       module RecordID
         extend ::ActiveSupport::Concern
 
@@ -26,17 +36,39 @@ module FmRest
           self.primary_key = :__record_id
         end
 
-        def record_id?
-          record_id.present?
+        def __record_id?
+          __record_id.present?
+        end
+        alias_method :record_id?, :__record_id?
+        alias_method :persisted?, :__record_id?
+
+        # Spyke override -- Use `__record_id` instead of `id`
+        #
+        def hash
+          __record_id.hash
         end
 
+        # Spyke override -- Renders class string with layout name and
+        # `record_id`.
+        #
+        # @return [String] A string representation of the class
+        #
         def inspect
-          "#<#{self.class} record_id: #{record_id.inspect} #{inspect_attributes}>"
+          "#<#{self.class}(layout: #{self.class.layout}) record_id: #{__record_id.inspect} #{inspect_attributes}>"
+        end
+
+        # Spyke override -- Use `__record_id` instead of `id`
+        #
+        # @param id [Integer] The id of the record to destroy
+        #
+        def destroy(id = nil)
+          new(__record_id: id).destroy
         end
 
         private
 
-        # Spyke Override
+        # Spyke override (private)
+        #
         def conflicting_ids?(attributes)
           false
         end

--- a/lib/fmrest/spyke/model/serialization.rb
+++ b/lib/fmrest/spyke/model/serialization.rb
@@ -7,8 +7,8 @@ module FmRest
         FM_DATE_FORMAT = "%m/%d/%Y"
         FM_DATETIME_FORMAT = "#{FM_DATE_FORMAT} %H:%M:%S"
 
-        # Override Spyke's to_params to return FM Data API's expected JSON
-        # format, and including only modified fields
+        # Spyke override -- Return FM Data API's expected JSON format,
+        # including only modified fields.
         #
         def to_params
           params = {

--- a/lib/fmrest/spyke/model/uri.rb
+++ b/lib/fmrest/spyke/model/uri.rb
@@ -3,7 +3,7 @@
 module FmRest
   module Spyke
     module Model
-      module Uri
+      module URI
         extend ::ActiveSupport::Concern
 
         class_methods do
@@ -14,13 +14,12 @@ module FmRest
             @layout ||= model_name.name
           end
 
-          # Extend uri acccessor to default to FM Data schema
+          # Spyke override -- Extends `uri` to default to FM Data's URI schema
           #
           def uri(uri_template = nil)
             if @uri.nil? && uri_template.nil?
               return FmRest::V1.record_path(layout) + "(/:#{primary_key})"
             end
-
             super
           end
         end

--- a/lib/fmrest/spyke/model/uri.rb
+++ b/lib/fmrest/spyke/model/uri.rb
@@ -18,7 +18,7 @@ module FmRest
           #
           def uri(uri_template = nil)
             if @uri.nil? && uri_template.nil?
-              return FmRest::V1.record_path(layout) + "(/:id)"
+              return FmRest::V1.record_path(layout) + "(/:#{primary_key})"
             end
 
             super

--- a/lib/fmrest/spyke/spyke_formatter.rb
+++ b/lib/fmrest/spyke/spyke_formatter.rb
@@ -63,8 +63,8 @@ module FmRest
         response = json[:response]
 
         data = {}
-        data[:mod_id] = response[:modId] if response[:modId]
-        data[:id]     = response[:recordId].to_i if response[:recordId]
+        data[:__mod_id] = response[:modId] if response[:modId]
+        data[:__record_id] = response[:recordId].to_i if response[:recordId]
 
         build_base_hash(json, true).merge!(data: data)
       end
@@ -188,7 +188,7 @@ module FmRest
       # @param json_data [Hash]
       # @return [Hash] the record data in Spyke format
       def prepare_record_data(json_data)
-        out = { id: json_data[:recordId].to_i, mod_id: json_data[:modId] }
+        out = { __record_id: json_data[:recordId].to_i, __mod_id: json_data[:modId] }
         out.merge!(json_data[:fieldData])
         out.merge!(prepare_portal_data(json_data[:portalData])) if json_data[:portalData]
         out
@@ -213,8 +213,8 @@ module FmRest
 
           out[portal_name] =
             portal_records.map do |portal_fields|
-              attributes = { id: portal_fields[:recordId].to_i }
-              attributes[:mod_id] = portal_fields[:modId] if portal_fields[:modId]
+              attributes = { __record_id: portal_fields[:recordId].to_i }
+              attributes[:__mod_id] = portal_fields[:modId] if portal_fields[:modId]
 
               prefix = portal_options[:attribute_prefix] || portal_name
               prefix_matcher = /\A#{prefix}::/

--- a/lib/fmrest/token_store/null.rb
+++ b/lib/fmrest/token_store/null.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+module FmRest
+  module TokenStore
+    module Null < Base
+      include Singleton
+
+      def delete(key)
+      end
+
+      def load(key)
+      end
+
+      def store(key, value)
+      end
+    end
+  end
+end

--- a/spec/fixtures/base.rb
+++ b/spec/fixtures/base.rb
@@ -1,2 +1,5 @@
-class FixtureBase < FmRest::Spyke::Base(FMREST_DUMMY_CONFIG)
+# frozen_string_literal: true
+
+class FixtureBase < FmRest::Spyke::Base
+  self.fmrest_config = FMREST_DUMMY_CONFIG
 end

--- a/spec/spyke/base_spec.rb
+++ b/spec/spyke/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe FmRest::Spyke::Base do
@@ -7,33 +9,5 @@ RSpec.describe FmRest::Spyke::Base do
 
   it "includes FmRest::Spyke::Model" do
     expect(FmRest::Spyke::Base.included_modules).to include(FmRest::Spyke::Model)
-  end
-
-  describe "method form" do
-    context "with config given" do
-      let(:subclass) { FmRest::Spyke::Base(host: "example.com") }
-
-      it "creates a subclass of FmRest::Spyke::Base" do
-        expect(subclass.superclass).to eq(::FmRest::Spyke::Base)
-      end
-
-      it "takes an argument and assigns it to fmrest_config" do
-        expect(subclass.fmrest_config.to_h).to eq(host: "example.com")
-      end
-    end
-
-    context "with no config given" do
-      let(:subclass) { FmRest::Spyke::Base() }
-
-      it "returns FmRest::Spyke::Base" do
-        expect(subclass).to eq(::FmRest::Spyke::Base)
-      end
-
-      it "doesn't set fmrest_config" do
-        dummy_settings = double("EmptyConnectionSettings")
-        allow(FmRest).to receive(:default_connection_settings).and_return(dummy_settings)
-        expect(subclass.fmrest_config).to eq(dummy_settings)
-      end
-    end
   end
 end

--- a/spec/spyke/container_field_spec.rb
+++ b/spec/spyke/container_field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FmRest::Spyke::ContainerField do
 
   let(:record) do
     double(FmRest::Spyke::Base, attributes: { "container" => url },
-                                id: 1,
+                                __record_id: 1,
                                 persisted?: true,
                                 class: model_class)
   end
@@ -45,8 +45,8 @@ RSpec.describe FmRest::Spyke::ContainerField do
     let(:io) { double(IO) }
 
     before do
-      allow(FmRest::V1).to receive(:upload_container_data).and_return(double("Response", body: { data: { mod_id: 99 } }))
-      allow(record).to receive(:mod_id=)
+      allow(FmRest::V1).to receive(:upload_container_data).and_return(double("Response", body: { data: { __mod_id: 99 } }))
+      allow(record).to receive(:__mod_id=)
     end
 
     context "with an unpersisted record" do
@@ -63,12 +63,12 @@ RSpec.describe FmRest::Spyke::ContainerField do
     end
 
     it "updates mod_id" do
-      expect(record).to receive(:mod_id=).with(99)
+      expect(record).to receive(:__mod_id=).with(99)
       container.upload(io)
     end
 
     it "returns true when successful" do
-      allow(record).to receive(:mod_id=)
+      allow(record).to receive(:__mod_id=)
       expect(container.upload(io)).to eq(true)
     end
   end

--- a/spec/spyke/model/associations_spec.rb
+++ b/spec/spyke/model/associations_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe FmRest::Spyke::Model::Associations do
           expect(ship.crew.size).to eq(2)
           expect(ship.crew.first).to be_a(Pirate)
           expect(ship.crew.first.name).to eq("Hendrick van der Decken")
-          expect(ship.crew.first.id).to eq(1)
+          expect(ship.crew.first.record_id).to eq(1)
           expect(ship.crew.first.mod_id).to eq("0")
           expect(ship.crew.first).to_not be_changed
-          expect(ship.crew.last.id).to eq(2)
+          expect(ship.crew.last.record_id).to eq(2)
         end
       end
     end

--- a/spec/spyke/model/attributes_spec.rb
+++ b/spec/spyke/model/attributes_spec.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require "spec_helper"
+require "fixtures/pirates"
 
 RSpec.describe FmRest::Spyke::Model::Attributes do
   let :test_class do
@@ -36,14 +39,6 @@ RSpec.describe FmRest::Spyke::Model::Attributes do
       expect(instance).to respond_to(:foo_will_change!)
       expect(instance.foo_changed?).to be(true)
     end
-
-    it "raises an error, if attempting to set an attribute named id" do
-      expect do
-        fmrest_spyke_class do
-          attributes id: "Foo", bar: "Bar"
-        end
-      end.to raise_error("attribute name `id' is reserved for the recordId")
-    end
   end
 
   describe ".mapped_attributes" do
@@ -53,34 +48,6 @@ RSpec.describe FmRest::Spyke::Model::Attributes do
 
     it "defaults to a HashWithIndifferentAccess" do
       expect(fmrest_spyke_class.mapped_attributes).to be_a(ActiveSupport::HashWithIndifferentAccess)
-    end
-  end
-
-  describe "#id_will_change!" do
-    it "is defined" do
-      expect(test_class.new).to respond_to(:id_will_change!)
-    end
-  end
-
-  describe "#id=" do
-    it "calls id_will_change!" do
-      instance = test_class.new
-      expect(instance).to receive(:id_will_change!)
-      instance.id = 1
-    end
-  end
-
-  describe "#mod_id" do
-    it "returns the current mod_id" do
-      expect(test_class.new.mod_id).to eq(nil)
-    end
-  end
-
-  describe "#mod_id=" do
-    it "sets the current mod_id" do
-      instance = test_class.new
-      instance.mod_id = 1
-      expect(instance.mod_id).to eq(1)
     end
   end
 
@@ -95,7 +62,7 @@ RSpec.describe FmRest::Spyke::Model::Attributes do
   end
 
   describe "#reload" do
-    let(:ship) { Ship.new id: 1, name: "Obra Djinn" }
+    let(:ship) { Ship.new __record_id: 1, name: "Obra Djinn" }
 
     before { stub_session_login }
 
@@ -113,7 +80,6 @@ RSpec.describe FmRest::Spyke::Model::Attributes do
       end
 
       it "resets changes information" do
-        ship = Ship.new id: 1, name: "Obra Djinn"
         expect { ship.reload }.to change { ship.changed? }.from(true).to(false)
       end
     end

--- a/spec/spyke/model/http_spec.rb
+++ b/spec/spyke/model/http_spec.rb
@@ -1,10 +1,11 @@
-require "spec_helper"
+# frozen_string_literal: true
 
+require "spec_helper"
 require "fixtures/pirates"
 
 RSpec.describe FmRest::Spyke::Model::Http do
   describe ".request" do
-    let(:ship) { Ship.new id: 1, name: "Obra Djinn" }
+    let(:ship) { Ship.new __record_id: 1, name: "Obra Djinn" }
 
     before { stub_session_login }
 
@@ -32,6 +33,47 @@ RSpec.describe FmRest::Spyke::Model::Http do
 
       t1.join
       t2.join
+    end
+  end
+
+  # NOTE: .find is a core Spyke method which we don't override, but we're
+  # testing here anyway since the changes to #uri bellow affect it
+  describe ".find" do
+    before { stub_session_login }
+
+    it "sends the proper request" do
+      request = stub_request(:get, fm_url(layout: "Ships") + "/records/1").to_return_fm(
+        data: [{ recordId: "1", fieldData: {} }]
+      )
+      Ship.find(1)
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#uri" do
+    context "when the record is persisted" do
+      it "returns a Spyke::Path object with the record_id set in params" do
+        uri = Ship.new(__record_id: 1, name: "Obra Djinn" ).uri
+        expect(uri).to be_a(::Spyke::Path)
+        # This is ugly but Spyke::Path provides no public reader for params
+        expect(uri.instance_variable_get(:@params)).to match(__record_id: 1)
+      end
+    end
+
+    context "when the record is not persisted" do
+      it "returns a Spyke::Path object with no record_id set in params" do
+        uri = Ship.new(name: "Obra Djinn").uri
+        expect(uri).to be_a(::Spyke::Path)
+        expect(uri.instance_variable_get(:@params)).to eq({})
+      end
+    end
+
+    context "when called within a scoped record" do
+      it "returns a Spyke::Path object with the record_id set in params" do
+        uri = Ship.where(__record_id: 1).new.uri
+        expect(uri).to be_a(::Spyke::Path)
+        expect(uri.instance_variable_get(:@params)).to match(__record_id: 1)
+      end
     end
   end
 end

--- a/spec/spyke/model/orm_spec.rb
+++ b/spec/spyke/model/orm_spec.rb
@@ -363,14 +363,14 @@ RSpec.describe FmRest::Spyke::Model::Orm do
   end
 
   describe "#destroy" do
-    let(:ship) { Ship.new name: "Mary Celeste", id: 1 }
+    let(:ship) { Ship.new name: "Mary Celeste", __record_id: 1 }
 
     before { stub_session_login }
 
     context "when called with script options" do
       it "adds script options to the query string" do
         request =
-          stub_request(:delete, fm_url(layout: "Ships", id: ship.id))
+          stub_request(:delete, fm_url(layout: "Ships", id: ship.record_id))
           .with(query: { "script" => "script", "script.param" => "param" })
           .to_return_fm
 
@@ -382,7 +382,7 @@ RSpec.describe FmRest::Spyke::Model::Orm do
   end
 
   describe "#reload" do
-    let(:ship) { Ship.new(id: 1) }
+    let(:ship) { Ship.new(__record_id: 1) }
 
     before { stub_session_login }
 

--- a/spec/spyke/model/record_id_spec.rb
+++ b/spec/spyke/model/record_id_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FmRest::Spyke::Model::RecordID do
+  let :test_class do
+    fmrest_spyke_class do
+      attributes foo: "Foo", bar: "Bar"
+    end
+  end
+
+  describe "primary_key" do
+    it "gets set to :__record_id" do
+      expect(test_class.primary_key).to eq(:__record_id)
+    end
+  end
+
+  describe "#__record_id" do
+    it "returns the current __record_id" do
+      expect(test_class.new.__record_id).to eq(nil)
+    end
+  end
+
+  describe "#__record_id=" do
+    it "sets the current record_id" do
+      instance = test_class.new
+      instance.__record_id = 1
+      expect(instance.record_id).to eq(1)
+    end
+  end
+
+  describe "#record_id" do
+    it "is an alias of #__record_id" do
+      expect(test_class.instance_method(:record_id)).to eq(test_class.instance_method(:__record_id))
+    end
+  end
+
+  describe "#id" do
+    it "is an alias of #__record_id" do
+      expect(test_class.instance_method(:id)).to eq(test_class.instance_method(:__record_id))
+    end
+  end
+
+  describe "#record_id?" do
+    it "returns true if __record_id is set" do
+      expect(test_class.new(__record_id: 1).record_id?).to eq(true)
+    end
+
+    it "returns false if __record_id is not set" do
+      expect(test_class.new.record_id?).to eq(false)
+    end
+  end
+
+  describe "#__mod_id" do
+    it "returns the current __mod_id" do
+      expect(test_class.new.__mod_id).to eq(nil)
+    end
+  end
+
+  describe "#__mod_id=" do
+    it "sets the current mod_id" do
+      instance = test_class.new
+      instance.__mod_id = 1
+      expect(instance.mod_id).to eq(1)
+    end
+  end
+
+  describe "#mod_id" do
+    it "is an alias of #__mod_id" do
+      expect(test_class.instance_method(:mod_id)).to eq(test_class.instance_method(:__mod_id))
+    end
+  end
+
+  describe "inspect" do
+    xit
+  end
+end

--- a/spec/spyke/model/record_id_spec.rb
+++ b/spec/spyke/model/record_id_spec.rb
@@ -41,13 +41,26 @@ RSpec.describe FmRest::Spyke::Model::RecordID do
     end
   end
 
-  describe "#record_id?" do
+  describe "#__record_id?" do
     it "returns true if __record_id is set" do
-      expect(test_class.new(__record_id: 1).record_id?).to eq(true)
+      expect(test_class.new(__record_id: 1).__record_id?).to eq(true)
     end
 
     it "returns false if __record_id is not set" do
-      expect(test_class.new.record_id?).to eq(false)
+      expect(test_class.new.__record_id?).to eq(false)
+    end
+  end
+
+  describe "#record_id?" do
+    it "is an alias of #__record_id?" do
+      expect(test_class.instance_method(:record_id?)).to eq(test_class.instance_method(:__record_id?))
+    end
+  end
+
+  describe "#hash" do
+    it "returns the hash of #__record_id" do
+      id = double(hash: "hashed!")
+      expect(test_class.new(__record_id: id).hash).to eq("hashed!")
     end
   end
 
@@ -71,7 +84,25 @@ RSpec.describe FmRest::Spyke::Model::RecordID do
     end
   end
 
-  describe "inspect" do
-    xit
+  describe "#inspect" do
+    it "returns a string representing the record class with id and attributes" do
+      allow(test_class).to receive(:to_s).and_return("TestClass")
+      instance = test_class.new(__record_id: 1, foo: "F00")
+      expect(instance.inspect).to eq(%{#<TestClass(layout: TestClass) record_id: 1 foo: "F00", bar: nil>})
+    end
+  end
+
+  describe "#persisted?" do
+    it "returns true if the record has a __record_id set" do
+      expect(test_class.new(__record_id: 1).persisted?).to eq(true)
+    end
+
+    it "returns false if the record has no __record_id set" do
+      expect(test_class.new.persisted?).to eq(false)
+    end
+  end
+
+  describe ".destroy" do
+    xit "destroys the record with the given record id"
   end
 end

--- a/spec/spyke/model/uri_spec.rb
+++ b/spec/spyke/model/uri_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FmRest::Spyke::Model::Uri do
 
   describe ".uri" do
     it "when called without args and a set layout it returns the FM Data URI" do
-      expect(test_class.uri).to eq("layouts/TestClass/records(/:id)")
+      expect(test_class.uri).to eq("layouts/TestClass/records(/:__record_id)")
     end
 
     it "when called with an arg it sets the URI" do

--- a/spec/spyke/model/uri_spec.rb
+++ b/spec/spyke/model/uri_spec.rb
@@ -1,8 +1,9 @@
-require "spec_helper"
+# frozen_string_literal: true
 
+require "spec_helper"
 require "fixtures/pirates"
 
-RSpec.describe FmRest::Spyke::Model::Uri do
+RSpec.describe FmRest::Spyke::Model::URI do
   let :test_class do
     fmrest_spyke_class
   end

--- a/spec/spyke/model_spec.rb
+++ b/spec/spyke/model_spec.rb
@@ -1,11 +1,4 @@
 require "spec_helper"
 
 RSpec.describe FmRest::Spyke::Model do
-  let(:test_class) { fmrest_spyke_class }
-
-  it "defines mod_id accessor" do
-    instance = test_class.new
-    expect(instance).to respond_to(:mod_id)
-    expect(instance).to respond_to(:mod_id=)
-  end
 end

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe FmRest::Spyke::Relation do
     end
 
     context "when the primary key is set" do
-      let(:scope) { relation.limit(10).offset(1).sort(:foo).query(foo: 1).where(id: 1) }
+      let(:scope) { relation.limit(10).offset(1).sort(:foo).query(foo: 1).where(__record_id: 1) }
 
       it "ignores collection parameters and doesn't set limit = 1" do
         expect(scope).to receive(:without_collection_params)

--- a/spec/spyke/spyke_formatter_spec.rb
+++ b/spec/spyke/spyke_formatter_spec.rb
@@ -164,10 +164,10 @@ RSpec.describe FmRest::Spyke::SpykeFormatter do
       expect(response.body).to include(
         metadata: a_metadata_object.with_ok_message,
         data: {
-          id: 1,
-          mod_id: "1",
+          __record_id: 1,
+          __mod_id: "1",
           foo: "Foo",
-          portal1: [{ bar: "Bar", id: 1, mod_id: "1" }]
+          portal1: [{ bar: "Bar", __record_id: 1, __mod_id: "1" }]
         }
       )
     end
@@ -182,10 +182,10 @@ RSpec.describe FmRest::Spyke::SpykeFormatter do
           .with_ok_message
           .with_data_info(data_info),
         data: [{
-          id: 1,
-          mod_id: "1",
+          __record_id: 1,
+          __mod_id: "1",
           foo: "Foo",
-          portal1: [{ bar: "Bar", id: 1, mod_id: "1" }]
+          portal1: [{ bar: "Bar", __record_id: 1, __mod_id: "1" }]
         }]
       )
     end
@@ -200,10 +200,10 @@ RSpec.describe FmRest::Spyke::SpykeFormatter do
           .with_ok_message
           .with_data_info(data_info),
         data: [{
-          id: 1,
-          mod_id: "1",
+          __record_id: 1,
+          __mod_id: "1",
           foo: "Foo",
-          portal1: [{ bar: "Bar", id: 1, mod_id: "1" }]
+          portal1: [{ bar: "Bar", __record_id: 1, __mod_id: "1" }]
         }]
       )
     end
@@ -224,7 +224,7 @@ RSpec.describe FmRest::Spyke::SpykeFormatter do
         it "returns a hash with single record data" do
           expect(response.body).to include(
             metadata: a_metadata_object.with_ok_message,
-            data: { mod_id: "2" },
+            data: { __mod_id: "2" },
             errors: {}
           )
         end


### PR DESCRIPTION
This PR adds the ability to have FM fields called `id`, which was previously not possible because they would get clobbered by the `recordId`.