### PR TITLE
add #and querying method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, '3.0', 3.1, 3.2]
+        ruby: [2.7, '3.0', 3.1, 3.2]
         activerecord: ['5.0', 5.1, 5.2, '6.0', 6.1, '7.0']
         exclude:
-          - ruby: 2.6
-            activerecord: '7.0'
           - ruby: '3.0'
             activerecord: '5.0'
           - ruby: '3.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 0.25.0
+
+* Add `.and` query method
+* Fix crash when `.match` query method was given non-string values
+
 ### 0.24.0
 
 * Add `FmRest::Layout.ignore_mod_id` flag

--- a/README.md
+++ b/README.md
@@ -586,8 +586,9 @@ FM Data API reference: https://help.claris.com/en/data-api-guide/
 
 ## Supported Ruby versions
 
-fmrest-ruby is [tested against](https://github.com/beezwax/fmrest-ruby/actions?query=workflow%3ACI)
-Ruby 2.6 through 3.2.
+The latest fmrest-ruby is
+[tested against](https://github.com/beezwax/fmrest-ruby/actions?query=workflow%3ACI)
+Ruby 2.7 through 3.2.
 
 ## Gem development
 

--- a/docs/Querying.md
+++ b/docs/Querying.md
@@ -99,7 +99,7 @@ Passing `omit: true` in a conditions hash will cause FileMaker to exclude
 results matching that conditions hash (see also `.omit` below for a shorthand):
 
 ```ruby
-Honeybee.query(name: "=Hutch")
+Honeybee.query(name: "=Hutch", omit: true)
 # JSON -> {"query": [{"Bee Name": "=Hutch", "omit": "true"}]}
 ```
 

--- a/docs/Querying.md
+++ b/docs/Querying.md
@@ -142,7 +142,7 @@ Otherwise it will raise `ArgumentError`:
 
 ```ruby
 Honeybee.query(age: 42).omit(name: "Hutch").and(name: "Mitch")
-# ArgumentError: Cannot use "and" with "omit"
+# ArgumentError: Cannot use `and' with `omit'
 ```
 
 ### .match

--- a/docs/Querying.md
+++ b/docs/Querying.md
@@ -13,7 +13,7 @@ String conditions are sent unchanged in the request, so you can use
 ```ruby
 # Find records with names containing the word "Hutch"
 Honeybee.query(name: "=Hutch")
-# JSON -> {"query": [{"Bee Name": "=Hutch"}]}
+# JSON -> {"query": [{"Name": "=Hutch"}]}
 ```
 
 You can also pass date/datetime, or range Ruby objects as condition values, and
@@ -21,13 +21,13 @@ they'll be converted into their matching FileMaker search strings:
 
 ```ruby
 Honeybee.query(age: 18..))
-# JSON -> {"query": [{"Bee DOB": ">=18"}]}
+# JSON -> {"query": [{"DOB": ">=18"}]}
 
 Honeybee.query(date_of_birth: Date.today))
-# JSON -> {"query": [{"Bee DOB": "01/02/2021"}]}
+# JSON -> {"query": [{"DOB": "01/02/2021"}]}
 
 Honeybee.query(date_of_birth: (Date.today-1..Date.today))
-# JSON -> {"query": [{"Bee DOB": "01/01/2021..01/02/2021"}]}
+# JSON -> {"query": [{"DOB": "01/01/2021..01/02/2021"}]}
 ```
 
 Passing multiple attributes to `.query` in a single conditions hash will group
@@ -35,7 +35,7 @@ them in the same JSON object:
 
 ```ruby
 Honeybee.query(name: "=Hutch", age: 18..)
-# JSON -> {"query": [{"Bee Name": "=Hutch", "Bee Age": ">=18"}]}
+# JSON -> {"query": [{"Name": "=Hutch", "Age": ">=18"}]}
 ```
 
 Calling `.query` multiple times (through method chaining) will by default merge
@@ -44,7 +44,7 @@ search of the given conditions):
 
 ```ruby
 Honeybee.query(name: "=Hutch").query(age: 20)
-# JSON -> {"query": [{"Bee Name": "=Hutch", "Bee Age": 20}]}
+# JSON -> {"query": [{"Name": "=Hutch", "Age": 20}]}
 ```
 
 NOTE: Prior to version 0.15.0, fmrest-ruby behaved differently in the above case,
@@ -55,7 +55,7 @@ OR search:
 
 ```ruby
 Honeybee.query({ name: "=Hutch" }, { name: "=Maya" })
-# JSON -> {"query": [{"Bee Name": "Hutch"}, {"Bee Name": "Maya"}]}
+# JSON -> {"query": [{"Name": "Hutch"}, {"Name": "Maya"}]}
 ```
 
 Alternatively you can prefix `.or` to chained call to `.query` to specify that
@@ -64,11 +64,11 @@ instead of merged with pre-existing conditions:
 
 ```ruby
 Honeybee.query(name: "=Hutch").or.query(name: "=Maya")
-# JSON -> {"query": [{"Bee Name": "Hutch"}, {"Bee Name": "Maya"}]}
+# JSON -> {"query": [{"Name": "Hutch"}, {"Name": "Maya"}]}
 
 # .or accepts conditions directly as a shorthand for .or.query
 Honeybee.query(name: "=Hutch").or(name: "=Maya")
-# JSON -> {"query": [{"Bee Name": "Hutch"}, {"Bee Name": "Maya"}]}
+# JSON -> {"query": [{"Name": "Hutch"}, {"Name": "Maya"}]}
 ```
 
 You can also query portal parameters using a nested hash (provided that you
@@ -76,7 +76,7 @@ defined your portal in your layout class):
 
 ```ruby
 Honeybee.query(tasks: { urgency: "=Today" })
-# JSON -> {"query": [{"Bee Tasks::Urgency": "=Today"}]}
+# JSON -> {"query": [{"Tasks::Urgency": "=Today"}]}
 ```
 
 Passing strings instead of symbols for keys allows you to pass literal field
@@ -84,15 +84,15 @@ names, useful if for some reason you haven't defined attributes or portals in
 your layout class:
 
 ```ruby
-Honeybee.query("Bee Age" => 4, "Bee Tasks::Urgency" => "=Today")
-# JSON -> {"query": [{"Bee Age": 4, "Bee Tasks::Urgency": "=Today"}]}
+Honeybee.query("Age" => 4, "Tasks::Urgency" => "=Today")
+# JSON -> {"query": [{"Age": 4, "Tasks::Urgency": "=Today"}]}
 ```
 
 Passing `nil` as a condition will search for an empty field:
 
 ```ruby
 Honeybee.query(name: nil)
-# JSON -> {"query": [{"Bee Name": "="}]}
+# JSON -> {"query": [{"Name": "="}]}
 ```
 
 Passing `omit: true` in a conditions hash will cause FileMaker to exclude
@@ -100,7 +100,7 @@ results matching that conditions hash (see also `.omit` below for a shorthand):
 
 ```ruby
 Honeybee.query(name: "=Hutch", omit: true)
-# JSON -> {"query": [{"Bee Name": "=Hutch", "omit": "true"}]}
+# JSON -> {"query": [{"Name": "=Hutch", "omit": "true"}]}
 ```
 
 See `.match` below for a convenience exact-match companion for `.query`.
@@ -112,14 +112,14 @@ the resulting JSON:
 
 ```ruby
 Honeybee.omit(name: "Hutch")
-# JSON -> {"query": [{"Bee Name": "Hutch", "omit": "true"}]}
+# JSON -> {"query": [{"Name": "Hutch", "omit": "true"}]}
 ```
 
 You can get the same effect by passing `omit: true` to `.query`:
 
 ```ruby
 Honeybee.query(name: "Hutch", omit: true)
-# JSON -> {"query": [{"Bee Name": "Hutch", "omit": "true"}]}
+# JSON -> {"query": [{"Name": "Hutch", "omit": "true"}]}
 ```
 
 ### .and
@@ -128,14 +128,15 @@ Honeybee.query(name: "Hutch", omit: true)
 
 ```ruby
 Honeybee.query({ name: "Hutch" }, { name: "Mitch" }).and(age: 42)
-# JSON -> {"query": [{"Bee DOB": "42", "Bee Name": "Hutch"}, {"Bee DOB": "42", "Bee Name": "Mitch"}]}
+# JSON -> {"query": [{"DOB": "42", "Name": "Hutch"}, {"DOB": "42", "Name": "Mitch"}]}
 ```
 
-NOTE: `.and` may only be used with `.omit` (or `omit: true`) when omitting the last clause in the query:
+NOTE: `.and` may only be used with `.omit` (or `omit: true`) when omitting the
+last clauses in the query:
 
 ```ruby
 Honeybee.query(age: 42).and(name: "Mitch").omit(name: "Hutch")
-# JSON -> {"query": [{"Bee DOB": "42", "Bee Name": "Mitch"}, {"Bee Name": "Hutch", "omit": "true"}]}
+# JSON -> {"query": [{"DOB": "42", "Name": "Mitch"}, {"Name": "Hutch", "omit": "true"}]}
 ```
 
 Otherwise it will raise `ArgumentError`:
@@ -154,7 +155,7 @@ address:
 
 ```ruby
 Honeybee.match(email: "hutch@thehive.bee")
-# JSON -> {"query": [{"Bee Email": "==hutch\@thehive.bee"}]}
+# JSON -> {"query": [{"Email": "==hutch\@thehive.bee"}]}
 ```
 
 You can also combine `.or.match` the same way you can `.or.query` to add

--- a/docs/Querying.md
+++ b/docs/Querying.md
@@ -122,6 +122,29 @@ Honeybee.query(name: "Hutch", omit: true)
 # JSON -> {"query": [{"Bee Name": "Hutch", "omit": "true"}]}
 ```
 
+### .and
+
+`.and` takes the Cartesian product of existing and new parameters:
+
+```ruby
+Honeybee.query({ name: "Hutch" }, { name: "Mitch" }).and(age: 42)
+# JSON -> {"query": [{"Bee DOB": "42", "Bee Name": "Hutch"}, {"Bee DOB": "42", "Bee Name": "Mitch"}]}
+```
+
+NOTE: `.and` may only be used with `.omit` (or `omit: true`) when omitting the last clause in the query:
+
+```ruby
+Honeybee.query(age: 42).and(name: "Mitch").omit(name: "Hutch")
+# JSON -> {"query": [{"Bee DOB": "42", "Bee Name": "Mitch"}, {"Bee Name": "Hutch", "omit": "true"}]}
+```
+
+Otherwise it will raise `ArgumentError`:
+
+```ruby
+Honeybee.query(age: 42).omit(name: "Hutch").and(name: "Mitch")
+# ArgumentError: Cannot use "and" with "omit"
+```
+
 ### .match
 
 Similar to `.query`, but sets exact string match conditions by prefixing `==`

--- a/docs/Querying.md
+++ b/docs/Querying.md
@@ -21,7 +21,7 @@ they'll be converted into their matching FileMaker search strings:
 
 ```ruby
 Honeybee.query(age: 18..))
-# JSON -> {"query": [{"DOB": ">=18"}]}
+# JSON -> {"query": [{"Age": ">=18"}]}
 
 Honeybee.query(date_of_birth: Date.today))
 # JSON -> {"query": [{"DOB": "01/02/2021"}]}
@@ -127,8 +127,23 @@ Honeybee.query(name: "Hutch", omit: true)
 `.and` takes the Cartesian product of existing and new parameters:
 
 ```ruby
-Honeybee.query({ name: "Hutch" }, { name: "Mitch" }).and(age: 42)
-# JSON -> {"query": [{"DOB": "42", "Name": "Hutch"}, {"DOB": "42", "Name": "Mitch"}]}
+Honeybee.query({ name: "Hutch" }, { name: "Mitch" }).and({ age: 42 }, { age: 84 )
+# JSON -> {"query":
+#           [
+#             {"Name": "Hutch", "Age": "42"},
+#             {"Name": "Hutch", "Age": "84"},
+#             {"Name": "Mitch", "Age": "42"},
+#             {"Name": "Mitch", "Age": "84"}
+#           ]
+#         }
+```
+
+You can also chain `.and` with `.match` to perform the same operation with
+exact matches:
+
+```ruby
+Honeybee.match({ name: "Hutch" }, { name: "Mitch" }).and.match({ age: 42 })
+# JSON -> {"query": [{"Name": "==Hutch", "Age": "==42"}, {"Name": "==Mutch", "Age": "==42"}]}
 ```
 
 NOTE: `.and` may only be used with `.omit` (or `omit: true`) when omitting the
@@ -136,7 +151,7 @@ last clauses in the query:
 
 ```ruby
 Honeybee.query(age: 42).and(name: "Mitch").omit(name: "Hutch")
-# JSON -> {"query": [{"DOB": "42", "Name": "Mitch"}, {"Name": "Hutch", "omit": "true"}]}
+# JSON -> {"query": [{"Age": "42", "Name": "Mitch"}, {"Name": "Hutch", "omit": "true"}]}
 ```
 
 Otherwise it will raise `ArgumentError`:

--- a/lib/fmrest/spyke/model/orm.rb
+++ b/lib/fmrest/spyke/model/orm.rb
@@ -25,7 +25,7 @@ module FmRest
           delegate :limit, :offset, :sort, :order, :query, :match, :omit,
             :portal, :portals, :includes, :with_all_portals, :without_portals,
             :script, :find_one, :first, :any, :find_some, :find_in_batches,
-            :find_each, to: :all
+            :find_each, :and, :or, to: :all
 
           # Spyke override -- Use FmRest's Relation instead of Spyke's vanilla
           # one
@@ -55,6 +55,8 @@ module FmRest
             end
 
             previous, self.current_scope = current_scope, scope
+
+            return if current_scope.instance_of?(FmRest::Spyke::EmptyRelation)
 
             # The DAPI returns a 401 "No records match the request" error when
             # nothing matches a _find request, so we need to catch it in order

--- a/lib/fmrest/spyke/model/orm.rb
+++ b/lib/fmrest/spyke/model/orm.rb
@@ -34,9 +34,9 @@ module FmRest
             current_scope || Relation.new(self, uri: uri)
           end
 
-          # Spyke override -- allows properly setting limit, offset and other
-          # options, as well as using the appropriate HTTP method/URL depending
-          # on whether there's a query present in the current scope.
+          # Spyke override -- properly sets limit, offset and other options, as
+          # well as using the appropriate HTTP method/URL depending on whether
+          # there's a query present in the current scope.
           #
           # @option options [Boolean] :raise_on_no_matching_records whether to
           #   raise `APIError::NoMatchingRecordsError` when no records match (FM
@@ -55,8 +55,6 @@ module FmRest
             end
 
             previous, self.current_scope = current_scope, scope
-
-            return if current_scope.instance_of?(FmRest::Spyke::EmptyRelation)
 
             # The DAPI returns a 401 "No records match the request" error when
             # nothing matches a _find request, so we need to catch it in order

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -211,19 +211,8 @@ module FmRest
             r.query_params = r
               .query_params
               .product(params)
-              .map do |old_params, new_params|
-                merge = old_params
-                  .transform_values { |value| Set[value] }
-                  .merge(
-                    new_params.transform_values { |value| Set[value] }
-                  ) { |_, old_value, new_value| old_value | new_value }
-
-                if merge.values.any?(&:many?)
-                  nil # reject params with different values for the same key
-                else
-                  merge.transform_values(&:first)
-                end
-              end.compact
+              .map { |a, b| a.merge(b) { |_, v1, v2| v1 == v2 ? v1 : nil } }
+              .reject { |hash| hash.values.any?(&:nil?) }
           end
         end
       end

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -272,7 +272,7 @@ module FmRest
         params = params.map { |p| normalize_query_params(p) }
 
         if query_params.including(params).any? { |param| param.key?("omit") }
-          raise ArgumentError, 'Cannot use "and" with "omit"'
+          raise ArgumentError, "Cannot use `and' with `omit'"
         end
 
         clone = with_clone do |r|

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -239,7 +239,7 @@ module FmRest
       # @return [FmRest::Spyke::Relation] a new relation with the given find
       #   conditions applied negated
       def omit(params)
-        query(params.merge(omit: true))
+        query.or(params.merge(omit: true))
       end
 
       # Signals that the next query conditions to be set (through `.query`,

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -5,6 +5,8 @@ module FmRest
     class Relation < ::Spyke::Relation
       SORT_PARAM_MATCHER = /(.*?)(!|__desc(?:end)?)?\Z/.freeze
 
+      ImpossibleValue = Object.new.freeze
+
       class UnknownQueryKey < ArgumentError; end
 
       # NOTE: We need to keep limit, offset, sort, query and portal accessors
@@ -283,8 +285,10 @@ module FmRest
               r
                 .query_params
                 .product(params)
-                .map { |a, b| a.merge(b) { |_, v1, v2| v1 == v2 ? v1 : nil } }
-                .reject { |hash| hash.values.any?(&:nil?) }
+                # A field cannot hold two values at the same time, so mark
+                # those cases for removal:
+                .map { |a, b| a.merge(b) { |_, v1, v2| v1 == v2 ? v1 : ImpossibleValue } }
+                .reject { |hash| hash.values.any?(ImpossibleValue) }
           end
         end
 

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -245,7 +245,7 @@ module FmRest
       # @return [FmRest::Spyke::Relation] a new relation with the exact match
       #   conditions applied
       def match(*params)
-        query(transform_query_values(params) { |v| "==#{FmRest::V1.escape_find_operators(v)}" })
+        query(transform_query_values(params) { |v| "==#{FmRest::V1.escape_find_operators(v.to_s)}" })
       end
 
       # Adds a new set of conditions to omit in a find request.

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -273,7 +273,7 @@ module FmRest
       def and(*params)
         params = params.map { |p| normalize_query_params(p) }
 
-        if query_params.including(params).any? { |param| param.key?("omit") }
+        if (query_params + params).any? { |param| param.key?("omit") }
           raise ArgumentError, "Cannot use `and' with `omit'"
         end
 

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -304,10 +304,40 @@ module FmRest
       # [{name: "Alice", age: 20}, {name: "Bob", age: 20}]
       # ```
       #
+      # Or in pseudocode logical representation:
+      #
+      # ```
+      # (name = "Alice" OR name = "Bob") AND age = 20
+      # ```
+      #
+      # You can also pass multiple condition hashes to `.and`, in which case
+      # it will treat them as OR-separated, e.g.:
+      #
+      # ```
+      # .query({ name: "Alice" }, { name: "Bob" }).and({ age: 20 }, { age: 30 })
+      # ```
+      #
+      # Would result in the following conditions:
+      #
+      # ```
+      # [
+      #   {name: "Alice", age: 20 },
+      #   {name: "Alice", age: 30 },
+      #   {name: "Bob", age: 20 },
+      #   {name: "Bob", age: 30 }
+      # ]
+      # ```
+      #
+      # In pseudocode:
+      #
+      # ```
+      # (name = "Alice" OR name = "Bob") AND (age = 20 OR age = 30)
+      # ```
+      #
       # You can call this method with or without parameters. If parameters are
       # given they will be passed down to `.query` (and those conditions
       # immediately set), otherwise it just prepares the next
-      # conditions-setting method (e.g. `match`) to use OR.
+      # conditions-setting method (e.g. `match`) to use AND.
       #
       # Note that if you use this method on fields that already had conditions
       # set you may end up with an unsatisfiable condition (e.g. name matches
@@ -320,9 +350,11 @@ module FmRest
       #   Person.query(name: "=Alice").and(city: "=Wonderland")
       #   # Add exact match conditions through method chaining:
       #   Person.match(name: "Alice").and.match(city: "Wonderland")
+      #   # With multiple condition hashes:
+      #   Person.query(name: "=Alice").and({ city: "=Wonderland" }, { city: "=London" })
       #   # With conflicting criteria:
       #   Person.match(name: "Alice").and.match(name: "Bob")
-      #   # => JSON: { "name": "1001..1000" }
+      #   # => JSON: { "name": "1001..1000" } -> forced empty result set
       def and(*params)
         clone = with_clone { |r| r.chain_flag = :and }
         params.empty? ? clone : clone.query(*params)

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -234,19 +234,19 @@ module FmRest
         query(transform_query_values(params) { |v| "==#{FmRest::V1.escape_find_operators(v)}" })
       end
 
-      # Negated version of `.query`, sets conditions to omit in a find request.
+      # Adds a new set of conditions to omit in a find request.
       #
-      # This is the same as passing `omit: true` to `.query`.
+      # This is the same as passing `omit: true` to `.or`.
       #
       # @return [FmRest::Spyke::Relation] a new relation with the given find
       #   conditions applied negated
       def omit(params)
-        query.or(params.merge(omit: true))
+        self.or(params.merge(omit: true))
       end
 
       # Signals that the next query conditions to be set (through `.query`,
       # `.match`, etc.) should be added as a logical OR relative to previously
-      # set conditions (rather than the default AND).
+      # set conditions.
       #
       # In practice this means the JSON query request will have a new
       # conditions object appended, e.g.:
@@ -258,7 +258,7 @@ module FmRest
       # You can call this method with or without parameters. If parameters are
       # given they will be passed down to `.query` (and those conditions
       # immediately set), otherwise it just prepares the next
-      # conditions-setting method to use OR.
+      # conditions-setting method (e.g. `match`) to use OR.
       #
       # @example
       #   # Add conditions directly in .or call:

--- a/lib/fmrest/spyke/relation.rb
+++ b/lib/fmrest/spyke/relation.rb
@@ -579,11 +579,17 @@ module FmRest
         @old_relation = relation
       end
 
-      def find_one = nil
+      def find_one
+        nil
+      end
 
-      def find_some = []
+      def find_some
+        []
+      end
 
-      def query_params = []
+      def query_params
+        []
+      end
 
       def or(*params)
         @old_relation.query(*params)

--- a/lib/fmrest/version.rb
+++ b/lib/fmrest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FmRest
-  VERSION = "0.24.0"
+  VERSION = "0.25.0.rc1"
 end

--- a/spec/spyke/model/orm_spec.rb
+++ b/spec/spyke/model/orm_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe FmRest::Spyke::Model::Orm do
   %i[
     limit offset sort order query match omit portal portals includes
     without_portals with_all_portals script find_one first any find_some
-    find_in_batches find_each
+    find_in_batches find_each and or
   ].each do |delegator|
     describe ".#{delegator}" do
       let(:scope) { double("Relation") }

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -196,11 +196,28 @@ RSpec.describe FmRest::Spyke::Relation do
   end
 
   describe "#query" do
-    it "creates a new scope with the given query params merged with previous ones" do
-      query_scope = relation.query(foo: "Noodles").query({ bar: "Onions" }, { foo: "Meatballs" })
-      expect(query_scope).to_not eq(relation)
-      expect(query_scope).to be_a(FmRest::Spyke::Relation)
-      expect(query_scope.query_params).to eq([{ "foo" => "Noodles", "bar" => "Onions" }, { "foo" => "Meatballs" }])
+    context "when there is a key/value collision" do
+      it "creates a new scope with the given query params merged with previous ones" do
+        query_scope = relation.query(foo: "Noodles").query({ bar: "Onions" }, { foo: "Meatballs" })
+        expect(query_scope).to_not eq(relation)
+        expect(query_scope).to be_a(FmRest::Spyke::Relation)
+        expect(query_scope.query_params).to eq([{ "foo" => "Noodles", "bar" => "Onions" }])
+      end
+    end
+
+    context "when there are no key/value collisions" do
+      it "creates a new scope with all possible combinations of params" do
+        query_scope = relation
+          .query({ foo: "Meatballs" }, { foo: "Noodles" })
+          .query({ bar: "Onions" }, { bar: "Pickles" })
+
+        expect(query_scope.query_params).to eq [
+          { "foo" => "Meatballs", "bar" => "Onions" },
+          { "foo" => "Meatballs", "bar" => "Pickles" },
+          { "foo" => "Noodles",   "bar" => "Onions" },
+          { "foo" => "Noodles",   "bar" => "Pickles" }
+        ]
+      end
     end
 
     it "normalizes portal query fields when given a sub-hash" do

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe FmRest::Spyke::Relation do
 
   describe "#omit" do
     it "forwards params to #query with omit: true" do
-      expect(relation).to receive(:query).with({ foo: "Coffee", omit: true }).and_return("Yipee!")
+      expect(relation).to receive(:or).with({ foo: "Coffee", omit: true }).and_return("Yipee!")
       expect(relation.omit(foo: "Coffee")).to eq("Yipee!")
     end
   end

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe FmRest::Spyke::Relation do
       it "raises ArgumentError" do
         expect {
           relation.omit(foo: "Noodles").and(bar: "Meatballs")
-        }.to raise_error(ArgumentError, 'Cannot use "and" with "omit"')
+        }.to raise_error(ArgumentError, "Cannot use `and' with `omit'")
       end
     end
 
@@ -353,7 +353,7 @@ RSpec.describe FmRest::Spyke::Relation do
       it "raises ArgumentError" do
         expect {
           relation.and(foo: "Noodles", omit: true)
-        }.to raise_error(ArgumentError, 'Cannot use "and" with "omit"')
+        }.to raise_error(ArgumentError, "Cannot use `and' with `omit'")
       end
     end
 

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe FmRest::Spyke::Relation do
   end
 
   describe "#omit" do
-    it "forwards params to #query with omit: true" do
+    it "forwards params to #or with omit: true" do
       expect(relation).to receive(:or).with({ foo: "Coffee", omit: true }).and_return("Yipee!")
       expect(relation.omit(foo: "Coffee")).to eq("Yipee!")
     end

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -5,7 +5,7 @@ require "fixtures/pirates"
 RSpec.describe FmRest::Spyke::Relation do
   let(:test_class) do
     fmrest_spyke_class do
-      attributes :foo, :bar
+      attributes :foo, :bar, :qux
 
       has_portal :ships, portal_key: "Ships"
       has_portal :bridges, portal_key: "Bridges"
@@ -309,13 +309,14 @@ RSpec.describe FmRest::Spyke::Relation do
       it "creates a new scope with all possible combinations of params" do
         query_scope = relation
           .query({ foo: "Meatballs" }, { foo: "Noodles" })
-          .and({ bar: "Onions" }, { bar: "Pickles" })
+          .and({ bar: "Onions", qux: 1 }, { bar: "Pickles", qux: 2 })
 
+        # SQLish pseudocode: (foo = M OR foo = N) AND (bar = O OR bar = P)
         expect(query_scope.query_params).to eq [
-          { "foo" => "Meatballs", "bar" => "Onions" },
-          { "foo" => "Meatballs", "bar" => "Pickles" },
-          { "foo" => "Noodles",   "bar" => "Onions" },
-          { "foo" => "Noodles",   "bar" => "Pickles" }
+          { "foo" => "Meatballs", "bar" => "Onions",  "qux" => 1 },
+          { "foo" => "Meatballs", "bar" => "Pickles", "qux" => 2 },
+          { "foo" => "Noodles",   "bar" => "Onions",  "qux" => 1 },
+          { "foo" => "Noodles",   "bar" => "Pickles", "qux" => 2 }
         ]
       end
     end

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -196,28 +196,11 @@ RSpec.describe FmRest::Spyke::Relation do
   end
 
   describe "#query" do
-    context "when there is a key/value collision" do
-      it "creates a new scope with the given query params merged with previous ones" do
-        query_scope = relation.query(foo: "Noodles").query({ bar: "Onions" }, { foo: "Meatballs" })
-        expect(query_scope).to_not eq(relation)
-        expect(query_scope).to be_a(FmRest::Spyke::Relation)
-        expect(query_scope.query_params).to eq([{ "foo" => "Noodles", "bar" => "Onions" }])
-      end
-    end
-
-    context "when there are no key/value collisions" do
-      it "creates a new scope with all possible combinations of params" do
-        query_scope = relation
-          .query({ foo: "Meatballs" }, { foo: "Noodles" })
-          .query({ bar: "Onions" }, { bar: "Pickles" })
-
-        expect(query_scope.query_params).to eq [
-          { "foo" => "Meatballs", "bar" => "Onions" },
-          { "foo" => "Meatballs", "bar" => "Pickles" },
-          { "foo" => "Noodles",   "bar" => "Onions" },
-          { "foo" => "Noodles",   "bar" => "Pickles" }
-        ]
-      end
+    it "creates a new scope with the given query params merged with previous ones" do
+      query_scope = relation.query(foo: "Noodles").query({ bar: "Onions" }, { foo: "Meatballs" })
+      expect(query_scope).to_not eq(relation)
+      expect(query_scope).to be_a(FmRest::Spyke::Relation)
+      expect(query_scope.query_params).to eq([{ "foo" => "Noodles", "bar" => "Onions" }, { "foo" => "Meatballs" }])
     end
 
     it "normalizes portal query fields when given a sub-hash" do
@@ -300,6 +283,32 @@ RSpec.describe FmRest::Spyke::Relation do
     it "forwards params to .query() if any given" do
       query_scope = relation.query(foo: "Noodles").or(foo: "Meatballs")
       expect(query_scope.query_params).to eq([{ "foo" => "Noodles" }, { "foo" => "Meatballs" }])
+    end
+  end
+
+  describe "#and" do
+    context "when there is a key/value collision" do
+      it "creates a new scope with the given query params merged with previous ones" do
+        query_scope = relation.query(foo: "Noodles").and({ bar: "Onions" }, { foo: "Meatballs" })
+        expect(query_scope).to_not eq(relation)
+        expect(query_scope).to be_a(FmRest::Spyke::Relation)
+        expect(query_scope.query_params).to eq([{ "foo" => "Noodles", "bar" => "Onions" }])
+      end
+    end
+
+    context "when there are no key/value collisions" do
+      it "creates a new scope with all possible combinations of params" do
+        query_scope = relation
+          .query({ foo: "Meatballs" }, { foo: "Noodles" })
+          .and({ bar: "Onions" }, { bar: "Pickles" })
+
+        expect(query_scope.query_params).to eq [
+          { "foo" => "Meatballs", "bar" => "Onions" },
+          { "foo" => "Meatballs", "bar" => "Pickles" },
+          { "foo" => "Noodles",   "bar" => "Onions" },
+          { "foo" => "Noodles",   "bar" => "Pickles" }
+        ]
+      end
     end
   end
 

--- a/spec/spyke/relation_spec.rb
+++ b/spec/spyke/relation_spec.rb
@@ -272,6 +272,10 @@ RSpec.describe FmRest::Spyke::Relation do
         "Ships::name" => "==M\\@ry"
       }])
     end
+
+    it "works with numeric values" do
+      expect(relation.match(foo: 1).query_params).to eq([{ "foo" => "==1" }])
+    end
   end
 
   describe "#omit" do


### PR DESCRIPTION
This PR adds the `#and` querying method:

```
➜ bin/rails c
Loading development environment (Rails 7.0.4)
irb(main):001:0> Request.query(ein: 724661).and({ status: "New" }, { status: "Pending Approval" }, { status: "Open"}).query_params
=> [{"Requests~INVENTORY::EIN"=>724661, "Status"=>"New"}, {"Requests~INVENTORY::EIN"=>724661, "Status"=>"Pending Approval"}, {"Requests~INVENTORY::EIN"=>724661, "Status"=>"Open"}]
```