### PR TITLE
Unsatisfiable query options

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,6 @@
 --markup markdown
 --plugin activesupport-concern
 --exclude lib/generators/*
--
 lib/**/*.rb
+-
 docs/*

--- a/lib/fmrest/spyke.rb
+++ b/lib/fmrest/spyke.rb
@@ -8,6 +8,29 @@ require "fmrest/spyke/base"
 
 module FmRest
   module Spyke
+    class << self
+      # Sets the bahavior to use when creating an ORM query that can't be
+      # logically satisified. See the section on querying in the README for
+      # more info.
+      #
+      # Possible values:
+      #
+      # * `:raise` - Raise an `FmRest::Spyke::UnsatisfiableQuery` exception
+      #   (inherits from `ArgumentError`) when the unsatisifiable query is
+      #   created
+      # * `:request_silent` - Silently allow the unsatisifiable query to go
+      #   through, which will be translated in the Data API as `field:
+      #   "1001..1000"` (ensures zero results)
+      # * `:return_silent` - Silently return an empty resultset without issuing
+      #   a request to the Data API. Use this option if you don't care about
+      #   potential server-side side effects (e.g. scripts) of running a query.
+      # * `:return_warn` - Same as `:return_silent` but will `warn()` about the
+      #   unsatisifiable query
+      # * `:request_warn`/`nil` (default) - Same as `:request_silent`, but will
+      #   `warn()` about the unsatisifiable query
+      attr_accessor :on_unsatisifiable_query
+    end
+
     def self.included(base)
       base.include Model
     end


### PR DESCRIPTION
@marquete @turino 

This PR adds an option that affects the way the library behaves when dealing with unsatisfiable queries:

```ruby
FmRest::Spyke.on_unsatisifiable_query = :return_silent

Contact.query(first_name: "Jacob").and(first_name: "marquete")
# => [] (no Data API request sent)
Contact.query(first_name: "Jacob").and(first_name: "marquete").or(first_name: "Jacob")
# => issues a Data API request with first_name: "Jacob"

FmRest::Spyke.on_unsatisifiable_query = :request_silent
Contact.query(first_name: "Jacob").and(first_name: "marquete")
# => issues a Data API request with first_name: "1001..1000"

FmRest::Spyke.on_unsatisifiable_query = :raise
Contact.query(first_name: "Jacob").and(first_name: "marquete")
# => UnsatisfiableQuery error
```

Other options not showcased above are `:return_warn` and `:request_warn`, which will do the same as the first two examples, but also printing a `warn()` message.

This is missing updated specs and documentation, but I'd like your general input.