### PR TITLE
remove unsupported versions from workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, '3.0', 3.1, 3.2]
-        activerecord: ['5.0', 5.1, 5.2, '6.0', 6.1, '7.0']
-        exclude:
-          - ruby: '3.0'
-            activerecord: '5.0'
-          - ruby: '3.0'
-            activerecord: 5.1
-          - ruby: '3.0'
-            activerecord: 5.2
-          - ruby: 3.1
-            activerecord: '5.0'
-          - ruby: 3.1
-            activerecord: 5.1
-          - ruby: 3.1
-            activerecord: 5.2
-          - ruby: 3.2
-            activerecord: '5.0'
-          - ruby: 3.2
-            activerecord: 5.1
-          - ruby: 3.2
-            activerecord: 5.2
+        ruby: ['3.0', 3.1, 3.2]
+        activerecord: [6.1, '7.0']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Ruby 2.7 and Rails < 6.1 are no longer supported, and haven't been for a while now.